### PR TITLE
feat: 날짜 범위 계산 로직 수정

### DIFF
--- a/src/main/java/dailyquest/common/TimeUtil.kt
+++ b/src/main/java/dailyquest/common/TimeUtil.kt
@@ -2,26 +2,31 @@ package dailyquest.common
 
 import java.time.DayOfWeek
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.temporal.TemporalAdjusters
 
 
-fun LocalDate.firstDayOfQuarter() : LocalDateTime {
-    val quarter = (this.monthValue - 1) / 3 + 1
-    val startMonth = (quarter - 1) * 3 + 1
-    val startOfQuarter = this.withMonth(startMonth).withDayOfMonth(1)
+fun LocalDate.firstDayOfQuarter(): LocalDate {
+    val week = (this.dayOfYear-1) / 7
+    val quarter = week / 13
+    val weeks = quarter * 13L
+    val startWeek = this.withMonth(1).withDayOfMonth(1).plusWeeks(weeks)
 
-    return startOfQuarter.atTime(0, 0, 0)
+    return startWeek.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
 }
 
-fun LocalDate.lastDayOfQuarter() : LocalDateTime {
-    val quarter = (this.monthValue - 1) / 3 + 1
-    val endMonth = quarter * 3
-    val endOfQuarter = this.withMonth(endMonth).withDayOfMonth(1).plusMonths(1).minusDays(1)
+fun LocalDate.lastDayOfQuarter(): LocalDate {
+    val week = (this.dayOfYear-1) / 7
+    val quarter = week / 13
+    val weeks = (quarter + 1) * 13L
+    val endWeek = this.withMonth(1).withDayOfMonth(1).plusWeeks(weeks -1)
 
-    return endOfQuarter.atTime(23, 59, 59)
+    return endWeek.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
 }
 
-fun LocalDateTime.firstDayOfWeek() : LocalDate {
+fun LocalDate.firstDayOfWeek() : LocalDate {
     return LocalDate.from(this.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)))
+}
+
+fun LocalDate.firstDayOfMonth() : LocalDate {
+    return LocalDate.from(this.with(TemporalAdjusters.firstDayOfMonth()))
 }

--- a/src/test/java/dailyquest/common/TimeUtilUnitTest.kt
+++ b/src/test/java/dailyquest/common/TimeUtilUnitTest.kt
@@ -1,0 +1,108 @@
+package dailyquest.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+class TimeUtilUnitTest {
+
+    @DisplayName("분기 시작일 조회 시")
+    @Nested
+    inner class GetQuarterStartDate {
+
+        @DisplayName("시작일이 월요일이 아니면 분기 범위 이전 월요일을 반환한다")
+        @Test
+        fun `시작일이 월요일이 아니면 분기 범위 이전 월요일을 반환한다`() {
+            //given
+            // 분기 시작일 - 2023/07/01 일요일
+            val date = LocalDate.of(2023, 7, 1)
+
+            //when
+            val firstDayOfQuarter = date.firstDayOfQuarter()
+
+            //then
+            assertThat(firstDayOfQuarter.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+            assertThat(firstDayOfQuarter).isBefore(date)
+        }
+
+        @DisplayName("시작일이 월요일이면 시작일이 반환된다")
+        @Test
+        fun `시작일이 월요일이면 시작일이 반환된다`() {
+            //given
+            // 분기 시작일 - 2019/07/01 월요일
+            val date = LocalDate.of(2019, 7, 1)
+
+            //when
+            val firstDayOfQuarter = date.firstDayOfQuarter()
+
+            //then
+            assertThat(firstDayOfQuarter.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+            assertThat(firstDayOfQuarter).isEqualTo(date)
+        }
+
+        @DisplayName("호출 날짜에 알맞은 분기가 선택된다")
+        @Test
+        fun `호출 날짜에 알맞은 분기가 선택된다`() {
+            //given
+            val firstQuarterOfDate1 = LocalDate.of(2023, 1, 1)
+            val firstQuarterOfDate2 = firstQuarterOfDate1.plusWeeks(12)
+
+            val secondQuarterOfDate1 = firstQuarterOfDate1.plusWeeks(13)
+            val secondQuarterOfDate2 = secondQuarterOfDate1.plusWeeks(13).minusDays(1)
+            val thirdQuarterOfDate1 = secondQuarterOfDate1.plusWeeks(13)
+            val thirdQuarterOfDate2 = thirdQuarterOfDate1.plusWeeks(13).minusDays(1)
+            val fourthQuarterOfDate1 = thirdQuarterOfDate1.plusWeeks(13)
+            val fourthQuarterOfDate2 = fourthQuarterOfDate1.plusWeeks(13).minusDays(1)
+
+            //when
+            val firstDayOfFirstQuarter1 = firstQuarterOfDate1.firstDayOfQuarter()
+            val firstDayOfFirstQuarter2 = firstQuarterOfDate2.firstDayOfQuarter()
+
+            val lastDayOfFirstQuarter1 = firstQuarterOfDate1.lastDayOfQuarter()
+            val lastDayOfFirstQuarter2 = firstQuarterOfDate1.lastDayOfQuarter()
+
+            val firstDayOfSecondQuarter1 = secondQuarterOfDate1.firstDayOfQuarter()
+            val firstDayOfSecondQuarter2 = secondQuarterOfDate2.firstDayOfQuarter()
+            val lastDayOfSecondQuarter1 = secondQuarterOfDate1.lastDayOfQuarter()
+            val lastDayOfSecondQuarter2 = secondQuarterOfDate1.lastDayOfQuarter()
+
+            val firstDayOfThirdQuarter1 = thirdQuarterOfDate1.firstDayOfQuarter()
+            val firstDayOfThirdQuarter2 = thirdQuarterOfDate2.firstDayOfQuarter()
+            val lastDayOfThirdQuarter1 = thirdQuarterOfDate1.lastDayOfQuarter()
+            val lastDayOfThirdQuarter2 = thirdQuarterOfDate1.lastDayOfQuarter()
+
+            val firstDayOfFourthQuarter1 = fourthQuarterOfDate1.firstDayOfQuarter()
+            val firstDayOfFourthQuarter2 = fourthQuarterOfDate2.firstDayOfQuarter()
+            val lastDayOfFourthQuarter1 = fourthQuarterOfDate1.lastDayOfQuarter()
+            val lastDayOfFourthQuarter2 = fourthQuarterOfDate1.lastDayOfQuarter()
+
+            //then
+            assertThat(firstDayOfFirstQuarter1).isEqualTo(firstDayOfFirstQuarter2)
+            assertThat(lastDayOfFirstQuarter1).isEqualTo(lastDayOfFirstQuarter2)
+
+            assertThat(firstDayOfSecondQuarter1).isEqualTo(firstDayOfSecondQuarter2)
+            assertThat(lastDayOfSecondQuarter1).isEqualTo(lastDayOfSecondQuarter2)
+
+            assertThat(firstDayOfThirdQuarter1).isEqualTo(firstDayOfThirdQuarter2)
+            assertThat(lastDayOfThirdQuarter1).isEqualTo(lastDayOfThirdQuarter2)
+
+            assertThat(firstDayOfFourthQuarter1).isEqualTo(firstDayOfFourthQuarter2)
+            assertThat(lastDayOfFourthQuarter1).isEqualTo(lastDayOfFourthQuarter2)
+
+            assertThat(firstDayOfFirstQuarter1)
+                .isNotEqualTo(firstDayOfSecondQuarter1)
+                .isNotEqualTo(firstDayOfThirdQuarter1)
+                .isNotEqualTo(firstDayOfFourthQuarter1)
+
+            assertThat(lastDayOfFirstQuarter1)
+                .isNotEqualTo(lastDayOfSecondQuarter1)
+                .isNotEqualTo(lastDayOfThirdQuarter1)
+                .isNotEqualTo(lastDayOfFourthQuarter1)
+        }
+
+    }
+
+}


### PR DESCRIPTION
분기 구분 시 13주 단위로 구분하도록 변경
주의 시작일이 분기 범위를 벗어날 때도 처리
날짜 범위 계산 테스트 코드 추가