### PR TITLE
feat: 퀘스트 통계 조회 로직 수정

### DIFF
--- a/src/main/java/dailyquest/quest/dto/QuestLogSearchCondition.kt
+++ b/src/main/java/dailyquest/quest/dto/QuestLogSearchCondition.kt
@@ -2,40 +2,30 @@ package dailyquest.quest.dto
 
 import dailyquest.common.firstDayOfQuarter
 import dailyquest.common.lastDayOfQuarter
-import dailyquest.quest.entity.QuestState
-import dailyquest.quest.entity.QuestType
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.Period
 import java.time.temporal.TemporalAdjusters
-import java.util.*
-import java.util.function.Function
-import java.util.stream.Collectors
 
 
 class QuestLogSearchCondition(
-    var searchType: QuestLogSearchType = QuestLogSearchType.DAILY,
-    val startDate: LocalDate = LocalDate.now()
+    val searchType: QuestLogSearchType = QuestLogSearchType.DAILY,
+    val selectedDate: LocalDate = LocalDate.now()
 ) {
-
-    fun getSelectedDate() : LocalDate {
-        return startDate
-    }
 
     fun getStartDateOfSearchRange() : LocalDate {
 
         return when (searchType) {
-            QuestLogSearchType.WEEKLY -> startDate.firstDayOfQuarter()
-            QuestLogSearchType.MONTHLY -> startDate.with(TemporalAdjusters.firstDayOfYear())
-            else -> startDate.with(TemporalAdjusters.firstDayOfMonth())
+            QuestLogSearchType.WEEKLY -> selectedDate.firstDayOfQuarter()
+            QuestLogSearchType.MONTHLY -> selectedDate.with(TemporalAdjusters.firstDayOfYear())
+            else -> selectedDate.with(TemporalAdjusters.firstDayOfMonth())
         }
     }
 
     fun getEndDateOfSearchRange() : LocalDate {
         return when (searchType) {
-            QuestLogSearchType.WEEKLY -> startDate.lastDayOfQuarter()
-            QuestLogSearchType.MONTHLY -> startDate.with(TemporalAdjusters.lastDayOfYear())
-            else -> startDate.with(TemporalAdjusters.lastDayOfMonth())
+            QuestLogSearchType.WEEKLY -> selectedDate.lastDayOfQuarter()
+            QuestLogSearchType.MONTHLY -> selectedDate.with(TemporalAdjusters.lastDayOfYear())
+            else -> selectedDate.with(TemporalAdjusters.lastDayOfMonth())
         }
     }
 
@@ -45,6 +35,19 @@ class QuestLogSearchCondition(
             QuestLogSearchType.MONTHLY -> Period.ofMonths(1)
             else -> Period.ofDays(1)
         }
+    }
+
+    fun createResponseMapOfPeriodUnit() : Map<LocalDate, QuestStatisticsResponse> {
+        val startDateOfSearchRange = getStartDateOfSearchRange()
+        val endDateOfSearchRange = getEndDateOfSearchRange()
+
+        val responseMap: MutableMap<LocalDate, QuestStatisticsResponse> = mutableMapOf()
+
+        startDateOfSearchRange
+            .datesUntil(endDateOfSearchRange.plusDays(1), getPeriodUnitOfSearchType())
+            .forEach { responseMap[it] = QuestStatisticsResponse(it) }
+
+        return responseMap
     }
 
 }

--- a/src/main/java/dailyquest/quest/dto/QuestStatisticsResponse.java
+++ b/src/main/java/dailyquest/quest/dto/QuestStatisticsResponse.java
@@ -1,0 +1,72 @@
+package dailyquest.quest.dto;
+
+import dailyquest.quest.entity.QuestState;
+import dailyquest.quest.entity.QuestType;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class QuestStatisticsResponse {
+
+    private final LocalDate loggedDate;
+
+    private long completeCount = 0;
+    private long failCount = 0;
+    private long discardCount = 0;
+
+    private long mainCount = 0;
+    private long subCount = 0;
+
+    private long stateRatio = 0;
+    private long typeRatio = 0;
+
+    public QuestStatisticsResponse(LocalDate loggedDate) {
+        this.loggedDate = loggedDate;
+    }
+
+    public void addStateCount(String state, long count) {
+        switch (QuestState.valueOf(state)) {
+            case COMPLETE -> completeCount += count;
+            case DISCARD -> discardCount += count;
+            case FAIL -> failCount += count;
+        }
+    }
+
+    public void addTypeCount(String type, long count) {
+        switch (QuestType.valueOf(type)) {
+            case MAIN -> mainCount += count;
+            case SUB -> subCount += count;
+        }
+    }
+
+    public void calcTypeRatio() {
+        long allQuestCount = mainCount + subCount;
+
+        if(allQuestCount == 0) return;
+
+        double ratio = (double) mainCount / allQuestCount;
+        double percent = ratio * 100;
+        typeRatio = Math.round(percent);
+    }
+
+    public void calcStateRatio() {
+        long allQuestCount = completeCount + failCount + discardCount;
+
+        if(allQuestCount == 0) return;
+
+        double ratio = (double) completeCount / allQuestCount;
+        double percent = ratio * 100;
+        stateRatio = Math.round(percent);
+    }
+
+    public void combineCount(QuestStatisticsResponse other) {
+        this.completeCount += other.completeCount;
+        this.failCount += other.failCount;
+        this.discardCount += other.discardCount;
+
+        this.mainCount += other.mainCount;
+        this.subCount += other.subCount;
+    }
+
+}

--- a/src/main/java/dailyquest/quest/repository/QuestLogRepositoryCustom.java
+++ b/src/main/java/dailyquest/quest/repository/QuestLogRepositoryCustom.java
@@ -1,11 +1,11 @@
 package dailyquest.quest.repository;
 
 import dailyquest.quest.dto.QuestLogSearchCondition;
+import dailyquest.quest.dto.QuestStatisticsResponse;
 
-import java.time.LocalDate;
-import java.util.Map;
+import java.util.List;
 
 public interface QuestLogRepositoryCustom {
-    Map<LocalDate, Map<String, Long>> getQuestStatisticByState(Long userId, QuestLogSearchCondition condition);
-    Map<LocalDate, Map<String, Long>> getQuestStatisticByType(Long userId, QuestLogSearchCondition condition);
+
+    List<QuestStatisticsResponse> getGroupedQuestLogs(Long userId, QuestLogSearchCondition condition);
 }

--- a/src/test/java/dailyquest/common/TimeUtilUnitTest.kt
+++ b/src/test/java/dailyquest/common/TimeUtilUnitTest.kt
@@ -17,8 +17,8 @@ class TimeUtilUnitTest {
         @Test
         fun `시작일이 월요일이 아니면 분기 범위 이전 월요일을 반환한다`() {
             //given
-            // 분기 시작일 - 2023/07/01 일요일
-            val date = LocalDate.of(2023, 7, 1)
+            // 분기 시작일 - 2023/01/01 일요일
+            val date = LocalDate.of(2023, 1, 1)
 
             //when
             val firstDayOfQuarter = date.firstDayOfQuarter()
@@ -28,32 +28,19 @@ class TimeUtilUnitTest {
             assertThat(firstDayOfQuarter).isBefore(date)
         }
 
-        @DisplayName("시작일이 월요일이면 시작일이 반환된다")
+        @DisplayName("호출 날짜에 알맞은 분기 시작일이 반환된다")
         @Test
-        fun `시작일이 월요일이면 시작일이 반환된다`() {
-            //given
-            // 분기 시작일 - 2019/07/01 월요일
-            val date = LocalDate.of(2019, 7, 1)
-
-            //when
-            val firstDayOfQuarter = date.firstDayOfQuarter()
-
-            //then
-            assertThat(firstDayOfQuarter.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
-            assertThat(firstDayOfQuarter).isEqualTo(date)
-        }
-
-        @DisplayName("호출 날짜에 알맞은 분기가 선택된다")
-        @Test
-        fun `호출 날짜에 알맞은 분기가 선택된다`() {
+        fun `호출 날짜에 알맞은 분기 시작일이 반환된다`() {
             //given
             val firstQuarterOfDate1 = LocalDate.of(2023, 1, 1)
             val firstQuarterOfDate2 = firstQuarterOfDate1.plusWeeks(12)
 
             val secondQuarterOfDate1 = firstQuarterOfDate1.plusWeeks(13)
             val secondQuarterOfDate2 = secondQuarterOfDate1.plusWeeks(13).minusDays(1)
+
             val thirdQuarterOfDate1 = secondQuarterOfDate1.plusWeeks(13)
             val thirdQuarterOfDate2 = thirdQuarterOfDate1.plusWeeks(13).minusDays(1)
+
             val fourthQuarterOfDate1 = thirdQuarterOfDate1.plusWeeks(13)
             val fourthQuarterOfDate2 = fourthQuarterOfDate1.plusWeeks(13).minusDays(1)
 
@@ -61,48 +48,89 @@ class TimeUtilUnitTest {
             val firstDayOfFirstQuarter1 = firstQuarterOfDate1.firstDayOfQuarter()
             val firstDayOfFirstQuarter2 = firstQuarterOfDate2.firstDayOfQuarter()
 
-            val lastDayOfFirstQuarter1 = firstQuarterOfDate1.lastDayOfQuarter()
-            val lastDayOfFirstQuarter2 = firstQuarterOfDate1.lastDayOfQuarter()
-
             val firstDayOfSecondQuarter1 = secondQuarterOfDate1.firstDayOfQuarter()
             val firstDayOfSecondQuarter2 = secondQuarterOfDate2.firstDayOfQuarter()
-            val lastDayOfSecondQuarter1 = secondQuarterOfDate1.lastDayOfQuarter()
-            val lastDayOfSecondQuarter2 = secondQuarterOfDate1.lastDayOfQuarter()
 
             val firstDayOfThirdQuarter1 = thirdQuarterOfDate1.firstDayOfQuarter()
             val firstDayOfThirdQuarter2 = thirdQuarterOfDate2.firstDayOfQuarter()
-            val lastDayOfThirdQuarter1 = thirdQuarterOfDate1.lastDayOfQuarter()
-            val lastDayOfThirdQuarter2 = thirdQuarterOfDate1.lastDayOfQuarter()
 
             val firstDayOfFourthQuarter1 = fourthQuarterOfDate1.firstDayOfQuarter()
             val firstDayOfFourthQuarter2 = fourthQuarterOfDate2.firstDayOfQuarter()
-            val lastDayOfFourthQuarter1 = fourthQuarterOfDate1.lastDayOfQuarter()
-            val lastDayOfFourthQuarter2 = fourthQuarterOfDate1.lastDayOfQuarter()
 
             //then
             assertThat(firstDayOfFirstQuarter1).isEqualTo(firstDayOfFirstQuarter2)
-            assertThat(lastDayOfFirstQuarter1).isEqualTo(lastDayOfFirstQuarter2)
-
             assertThat(firstDayOfSecondQuarter1).isEqualTo(firstDayOfSecondQuarter2)
-            assertThat(lastDayOfSecondQuarter1).isEqualTo(lastDayOfSecondQuarter2)
-
             assertThat(firstDayOfThirdQuarter1).isEqualTo(firstDayOfThirdQuarter2)
-            assertThat(lastDayOfThirdQuarter1).isEqualTo(lastDayOfThirdQuarter2)
-
             assertThat(firstDayOfFourthQuarter1).isEqualTo(firstDayOfFourthQuarter2)
-            assertThat(lastDayOfFourthQuarter1).isEqualTo(lastDayOfFourthQuarter2)
 
             assertThat(firstDayOfFirstQuarter1)
                 .isNotEqualTo(firstDayOfSecondQuarter1)
                 .isNotEqualTo(firstDayOfThirdQuarter1)
                 .isNotEqualTo(firstDayOfFourthQuarter1)
+        }
+    }
+
+    @DisplayName("분기 종료일 조회 시")
+    @Nested
+    inner class GetQuarterEndDate {
+        @DisplayName("종료일이 일요일이 아닌 경우 분기 범위 밖의 날짜가 반환된다")
+        @Test
+        fun `종료일이 일요일이 아닌 경우 분기 범위 밖의 날짜가 반환된다`() {
+            //given
+            // 분기 종료일 - 2022/12/31 토요일
+            val date = LocalDate.of(2022, 12, 31)
+
+            //when
+            val firstDayOfQuarter = date.lastDayOfQuarter()
+
+            //then
+            assertThat(firstDayOfQuarter.dayOfWeek).isEqualTo(DayOfWeek.SUNDAY)
+            assertThat(firstDayOfQuarter).isAfter(date)
+        }
+
+        @DisplayName("호출 날짜에 알맞은 분기 종료 날짜가 반환된다")
+        @Test
+        fun `호출 날짜에 알맞은 분기 종료 날짜가 반환된다`() {
+            //given
+            val firstQuarterOfDate1 = LocalDate.of(2023, 1, 1)
+            val firstQuarterOfDate2 = firstQuarterOfDate1.plusWeeks(12)
+
+            val secondQuarterOfDate1 = firstQuarterOfDate1.plusWeeks(13)
+            val secondQuarterOfDate2 = secondQuarterOfDate1.plusWeeks(13).minusDays(1)
+
+            val thirdQuarterOfDate1 = secondQuarterOfDate1.plusWeeks(13)
+            val thirdQuarterOfDate2 = thirdQuarterOfDate1.plusWeeks(13).minusDays(1)
+
+            val fourthQuarterOfDate1 = thirdQuarterOfDate1.plusWeeks(13)
+            val fourthQuarterOfDate2 = fourthQuarterOfDate1.plusWeeks(13).minusDays(1)
+
+            //when
+            val lastDayOfFirstQuarter1 = firstQuarterOfDate1.lastDayOfQuarter()
+            val lastDayOfFirstQuarter2 = firstQuarterOfDate2.lastDayOfQuarter()
+
+            val lastDayOfSecondQuarter1 = secondQuarterOfDate1.lastDayOfQuarter()
+            val lastDayOfSecondQuarter2 = secondQuarterOfDate2.lastDayOfQuarter()
+
+            val lastDayOfThirdQuarter1 = thirdQuarterOfDate1.lastDayOfQuarter()
+            val lastDayOfThirdQuarter2 = thirdQuarterOfDate2.lastDayOfQuarter()
+
+            val lastDayOfFourthQuarter1 = fourthQuarterOfDate1.lastDayOfQuarter()
+            val lastDayOfFourthQuarter2 = fourthQuarterOfDate2.lastDayOfQuarter()
+
+            //then
+            assertThat(lastDayOfFirstQuarter1).isEqualTo(lastDayOfFirstQuarter2)
+            assertThat(lastDayOfSecondQuarter1).isEqualTo(lastDayOfSecondQuarter2)
+            assertThat(lastDayOfThirdQuarter1).isEqualTo(lastDayOfThirdQuarter2)
+            assertThat(lastDayOfFourthQuarter1).isEqualTo(lastDayOfFourthQuarter2)
 
             assertThat(lastDayOfFirstQuarter1)
                 .isNotEqualTo(lastDayOfSecondQuarter1)
                 .isNotEqualTo(lastDayOfThirdQuarter1)
                 .isNotEqualTo(lastDayOfFourthQuarter1)
-        }
 
+        }
     }
+
+
 
 }

--- a/src/test/java/dailyquest/quest/dto/QuestLogSearchConditionUnitTest.java
+++ b/src/test/java/dailyquest/quest/dto/QuestLogSearchConditionUnitTest.java
@@ -1,0 +1,85 @@
+package dailyquest.quest.dto;
+
+import dailyquest.common.TimeUtilKt;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("퀘스트 로그 검색 조건 테스트")
+public class QuestLogSearchConditionUnitTest {
+
+    @DisplayName("시작 일자 요청 시 조회 타입에 따라 알맞은 값이 반환된다")
+    @Test
+    public void testGetStartDate() throws Exception {
+        //given
+        LocalDate now = LocalDate.now();
+        QuestLogSearchCondition dailyCondition = new QuestLogSearchCondition(QuestLogSearchType.DAILY, now);
+        QuestLogSearchCondition weeklyCondition = new QuestLogSearchCondition(QuestLogSearchType.WEEKLY, now);
+        QuestLogSearchCondition monthlyCondition = new QuestLogSearchCondition(QuestLogSearchType.MONTHLY, now);
+
+        //when
+        LocalDate dailyStart = dailyCondition.getStartDateOfSearchRange();
+        LocalDate weeklyStart = weeklyCondition.getStartDateOfSearchRange();
+        LocalDate monthlyStart = monthlyCondition.getStartDateOfSearchRange();
+
+        //then
+        assertThat(dailyStart).isEqualTo(now.with(TemporalAdjusters.firstDayOfMonth()));
+        assertThat(weeklyStart).isEqualTo(TimeUtilKt.firstDayOfQuarter(now));
+        assertThat(monthlyStart).isEqualTo(now.with(TemporalAdjusters.firstDayOfYear()));
+    }
+
+    @DisplayName("종료 일자 요청 시 조회 타입에 따라 알맞은 값이 반환된다")
+    @Test
+    public void testGetEndDate() throws Exception {
+        //given
+        LocalDate now = LocalDate.now();
+        QuestLogSearchCondition dailyCondition = new QuestLogSearchCondition(QuestLogSearchType.DAILY, now);
+        QuestLogSearchCondition weeklyCondition = new QuestLogSearchCondition(QuestLogSearchType.WEEKLY, now);
+        QuestLogSearchCondition monthlyCondition = new QuestLogSearchCondition(QuestLogSearchType.MONTHLY, now);
+
+        //when
+        LocalDate dailyEnd = dailyCondition.getEndDateOfSearchRange();
+        LocalDate weeklyEnd = weeklyCondition.getEndDateOfSearchRange();
+        LocalDate monthlyEnd = monthlyCondition.getEndDateOfSearchRange();
+
+        //then
+        assertThat(dailyEnd).isEqualTo(now.with(TemporalAdjusters.lastDayOfMonth()));
+        assertThat(weeklyEnd).isEqualTo(TimeUtilKt.lastDayOfQuarter(now));
+        assertThat(monthlyEnd).isEqualTo(now.with(TemporalAdjusters.lastDayOfYear()));
+    }
+
+    @DisplayName("응답 맵 생성 요청 시 조회 타입에 따라 알맞은 맵이 반환된다")
+    @Test
+    public void testCreateResponseMap() throws Exception {
+        //given
+        LocalDate now = LocalDate.now();
+        QuestLogSearchCondition dailyCondition = new QuestLogSearchCondition(QuestLogSearchType.DAILY, now);
+        QuestLogSearchCondition weeklyCondition = new QuestLogSearchCondition(QuestLogSearchType.WEEKLY, now);
+        QuestLogSearchCondition monthlyCondition = new QuestLogSearchCondition(QuestLogSearchType.MONTHLY, now);
+
+        LocalDate dailyStart = dailyCondition.getStartDateOfSearchRange();
+        LocalDate dailyEnd = dailyCondition.getEndDateOfSearchRange().plusDays(1);
+
+        LocalDate weeklyStart = weeklyCondition.getStartDateOfSearchRange();
+        LocalDate weeklyEnd = weeklyCondition.getEndDateOfSearchRange().plusDays(1);
+
+        LocalDate monthlyStart = monthlyCondition.getStartDateOfSearchRange();
+        LocalDate monthlyEnd = monthlyCondition.getEndDateOfSearchRange().plusDays(1);
+
+        //when
+        Map<LocalDate, QuestStatisticsResponse> dailyMap = dailyCondition.createResponseMapOfPeriodUnit();
+        Map<LocalDate, QuestStatisticsResponse> weeklyMap = weeklyCondition.createResponseMapOfPeriodUnit();
+        Map<LocalDate, QuestStatisticsResponse> monthlyMap = monthlyCondition.createResponseMapOfPeriodUnit();
+
+        //then
+        assertThat(dailyMap).containsOnlyKeys(dailyStart.datesUntil(dailyEnd, Period.ofDays(1)).toList());
+        assertThat(weeklyMap).containsOnlyKeys(weeklyStart.datesUntil(weeklyEnd, Period.ofWeeks(1)).toList());
+        assertThat(monthlyMap).containsOnlyKeys(monthlyStart.datesUntil(monthlyEnd, Period.ofMonths(1)).toList());
+    }
+}

--- a/src/test/java/dailyquest/quest/dto/QuestStatisticsResponseUnitTest.java
+++ b/src/test/java/dailyquest/quest/dto/QuestStatisticsResponseUnitTest.java
@@ -1,0 +1,135 @@
+package dailyquest.quest.dto;
+
+import dailyquest.quest.entity.QuestState;
+import dailyquest.quest.entity.QuestType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("퀘스트 통계 응답 DTO 유닛 테스트")
+public class QuestStatisticsResponseUnitTest {
+
+    @DisplayName("addStateCount 호출 시 상태에 따라 카운트가 더해진다")
+    @Test
+    public void testAddStateCount() throws Exception {
+        //given
+        QuestStatisticsResponse response = new QuestStatisticsResponse(LocalDate.now());
+        int completeCount = 3;
+        int failCount = 4;
+        int discardCount = 1;
+
+        //when
+        response.addStateCount(QuestState.COMPLETE.name(), completeCount);
+        response.addStateCount(QuestState.FAIL.name(), failCount);
+        response.addStateCount(QuestState.DISCARD.name(), discardCount);
+
+        //then
+        assertThat(response.getCompleteCount()).isEqualTo(completeCount);
+        assertThat(response.getFailCount()).isEqualTo(failCount);
+        assertThat(response.getDiscardCount()).isEqualTo(discardCount);
+
+        assertThat(response.getMainCount()).isEqualTo(0);
+        assertThat(response.getSubCount()).isEqualTo(0);
+    }
+
+    @DisplayName("addTypeCount 호출 시 타입에 따라 카운트가 더해진다")
+    @Test
+    public void testAddTypeCount() throws Exception {
+        //given
+        QuestStatisticsResponse response = new QuestStatisticsResponse(LocalDate.now());
+        int mainCount = 3;
+        int subCount = 1;
+
+        //when
+        response.addTypeCount(QuestType.MAIN.name(), mainCount);
+        response.addTypeCount(QuestType.SUB.name(), subCount);
+
+        //then
+        assertThat(response.getMainCount()).isEqualTo(mainCount);
+        assertThat(response.getSubCount()).isEqualTo(subCount);
+
+        assertThat(response.getCompleteCount()).isEqualTo(0);
+        assertThat(response.getFailCount()).isEqualTo(0);
+        assertThat(response.getDiscardCount()).isEqualTo(0);
+    }
+
+    @DisplayName("calcTypeRatio 호출 시 전체 타입 중 메인의 비율을 반환한다")
+    @Test
+    public void testCalcTypeRatio() throws Exception {
+        //given
+        QuestStatisticsResponse response = new QuestStatisticsResponse(LocalDate.now());
+        int mainCount = 5;
+        int subCount = 5;
+        int ratio = (int) (mainCount * 100f / (mainCount + subCount));
+        response.addTypeCount(QuestType.MAIN.name(), mainCount);
+        response.addTypeCount(QuestType.SUB.name(), subCount);
+
+        //when
+        response.calcTypeRatio();
+
+        //then
+        assertThat(response.getTypeRatio()).isEqualTo(ratio);
+    }
+
+    @DisplayName("calcStateRatio 호출 시 전체 상태 중 완료 상태 비율을 반환한다")
+    @Test
+    public void testCalcStateRatio() throws Exception {
+        //given
+        QuestStatisticsResponse response = new QuestStatisticsResponse(LocalDate.now());
+        int completeCount = 5;
+        int failCount = 4;
+        int discardCount = 1;
+        int ratio = (int) (completeCount * 100f / (failCount + discardCount + completeCount));
+
+        response.addStateCount(QuestState.COMPLETE.name(), completeCount);
+        response.addStateCount(QuestState.FAIL.name(), failCount);
+        response.addStateCount(QuestState.DISCARD.name(), discardCount);
+
+        //when
+        response.calcStateRatio();
+
+        //then
+        assertThat(response.getStateRatio()).isEqualTo(ratio);
+    }
+
+    @DisplayName("combineCount 호출 시 두 DTO의 카운트를 합친다")
+    @Test
+    public void testCombineCount() throws Exception {
+        //given
+        QuestStatisticsResponse response1 = new QuestStatisticsResponse(LocalDate.now());
+        QuestStatisticsResponse response2 = new QuestStatisticsResponse(LocalDate.now());
+
+        int completeCount = 1;
+        int failCount = 2;
+        int discardCount = 3;
+        int mainCount = 4;
+        int subCount = 5;
+
+        response1.addStateCount(QuestState.COMPLETE.name(), completeCount);
+        response1.addStateCount(QuestState.FAIL.name(), failCount);
+        response1.addStateCount(QuestState.DISCARD.name(), discardCount);
+        response1.addTypeCount(QuestType.MAIN.name(), mainCount);
+        response1.addTypeCount(QuestType.SUB.name(), subCount);
+
+        response2.addStateCount(QuestState.COMPLETE.name(), completeCount * 2);
+        response2.addStateCount(QuestState.FAIL.name(), failCount * 2);
+        response2.addStateCount(QuestState.DISCARD.name(), discardCount * 2);
+        response2.addTypeCount(QuestType.MAIN.name(), mainCount * 2);
+        response2.addTypeCount(QuestType.SUB.name(), subCount * 2);
+
+        //when
+        response1.combineCount(response2);
+
+        //then
+        assertThat(response1.getCompleteCount()).isEqualTo(completeCount * 3);
+        assertThat(response1.getFailCount()).isEqualTo(failCount * 3);
+        assertThat(response1.getDiscardCount()).isEqualTo(discardCount * 3);
+
+        assertThat(response1.getMainCount()).isEqualTo(mainCount * 3);
+        assertThat(response1.getSubCount()).isEqualTo(subCount * 3);
+    }
+
+}

--- a/src/test/java/dailyquest/quest/repository/QuestLogRepositoryUnitTest.java
+++ b/src/test/java/dailyquest/quest/repository/QuestLogRepositoryUnitTest.java
@@ -1,0 +1,101 @@
+package dailyquest.quest.repository;
+
+import dailyquest.config.JpaAuditingConfiguration;
+import dailyquest.quest.dto.QuestLogSearchCondition;
+import dailyquest.quest.dto.QuestStatisticsResponse;
+import dailyquest.quest.entity.Quest;
+import dailyquest.quest.entity.QuestLog;
+import dailyquest.quest.entity.QuestState;
+import dailyquest.quest.entity.QuestType;
+import dailyquest.user.entity.ProviderType;
+import dailyquest.user.entity.UserInfo;
+import dailyquest.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("퀘스트 로그 리포지토리 유닛 테스트")
+@DataJpaTest
+@Import(JpaAuditingConfiguration.class)
+public class QuestLogRepositoryUnitTest {
+
+    @Autowired
+    QuestLogRepository questLogRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    QuestRepository questRepository;
+
+    @DisplayName("퀘스트 통계 조회 시 타입과 상태 별로 그룹화된 카운트가 반환된다")
+    @Test
+    public void testGetQuestLog() throws Exception {
+        //given
+        UserInfo user = new UserInfo("", "user", ProviderType.GOOGLE);
+        UserInfo savedUser = userRepository.save(user);
+
+        int completeCount = 3;
+        int failCount = 2;
+        int discardCount = 5;
+
+        int mainCount = completeCount + failCount;
+
+        for (int i = 0; i < completeCount; i++) {
+            Quest quest = new Quest("quest", "desc", savedUser, 1, QuestState.COMPLETE, QuestType.MAIN, null);
+            Quest savedQuest = questRepository.save(quest);
+            questLogRepository.save(new QuestLog(savedQuest));
+        }
+
+        for (int i = 0; i < failCount; i++) {
+            Quest quest = new Quest("quest", "desc", savedUser, 1, QuestState.FAIL, QuestType.MAIN, null);
+            Quest savedQuest = questRepository.save(quest);
+            questLogRepository.save(new QuestLog(savedQuest));
+        }
+
+        for (int i = 0; i < discardCount; i++) {
+            Quest quest = new Quest("quest", "desc", savedUser, 1, QuestState.DISCARD, QuestType.SUB, null);
+            Quest savedQuest = questRepository.save(quest);
+            questLogRepository.save(new QuestLog(savedQuest));
+        }
+
+        Quest quest = new Quest("quest", "desc", savedUser, 1, QuestState.PROCEED, QuestType.SUB, null);
+        Quest savedQuest = questRepository.save(quest);
+        questLogRepository.save(new QuestLog(savedQuest));
+
+        LocalDate today = LocalDate.now();
+
+        //when
+        List<QuestStatisticsResponse> groupedQuestLogs = questLogRepository.getGroupedQuestLogs(savedUser.getId(), new QuestLogSearchCondition());
+
+        //then
+        assertThat(groupedQuestLogs).allMatch(log -> log.getLoggedDate().equals(today));
+        assertThat(groupedQuestLogs).anyMatch(log -> log.getCompleteCount() == completeCount);
+        assertThat(groupedQuestLogs).anyMatch(log -> log.getFailCount() == failCount);
+        assertThat(groupedQuestLogs).anyMatch(log -> log.getDiscardCount() == discardCount);
+        assertThat(groupedQuestLogs).anyMatch(log -> log.getMainCount() == mainCount);
+        assertThat(groupedQuestLogs).anyMatch(log -> log.getMainCount() == discardCount);
+    }
+
+    @DisplayName("퀘스트 통계 조회 시 조회되는 값이 없으면 빈 리스트가 반환된다")
+    @Test
+    public void testEmptyQuestLog() throws Exception {
+        //given
+        UserInfo user = new UserInfo("", "user", ProviderType.GOOGLE);
+        UserInfo savedUser = userRepository.save(user);
+
+        //when
+        List<QuestStatisticsResponse> groupedQuestLogs = questLogRepository.getGroupedQuestLogs(savedUser.getId(), new QuestLogSearchCondition());
+
+        //then
+        assertThat(groupedQuestLogs).isEmpty();
+    }
+
+}

--- a/src/test/java/dailyquest/quest/service/QuestLogServiceUnitTest.java
+++ b/src/test/java/dailyquest/quest/service/QuestLogServiceUnitTest.java
@@ -1,0 +1,111 @@
+package dailyquest.quest.service;
+
+import dailyquest.quest.dto.QuestLogSearchCondition;
+import dailyquest.quest.dto.QuestLogSearchType;
+import dailyquest.quest.dto.QuestStatisticsResponse;
+import dailyquest.quest.repository.QuestLogRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("퀘스트 로그 서비스 유닛 테스트")
+public class QuestLogServiceUnitTest {
+
+    @InjectMocks
+    QuestLogService questLogService;
+
+    @Mock
+    QuestLogRepository questLogRepository;
+
+    @DisplayName("일별 퀘스트 로그 조회")
+    @Test
+    public void 일별_퀘스트_로그_조회() throws Exception {
+        //given
+        int year = 2022;
+        int month = 3;
+        int day = 5;
+        LocalDate today = LocalDate.of(year, month, 5);
+
+        int yesterdayComplete = 3;
+        int yesterdayFail = 4;
+        int yesterdayDiscard = 2;
+
+        int todayComplete = 3;
+        int todayMain = 2;
+
+        List<QuestStatisticsResponse> groupedLogs = new ArrayList<>();
+
+        LocalDate yesterday = LocalDate.of(year, month, day - 1);
+        for (int i = 0; i < yesterdayComplete; i++) {
+            QuestStatisticsResponse e = new QuestStatisticsResponse(yesterday);
+            e.addStateCount("COMPLETE", 1);
+            groupedLogs.add(e);
+        }
+
+        for (int i = 0; i < yesterdayFail; i++) {
+            QuestStatisticsResponse e = new QuestStatisticsResponse(yesterday);
+            e.addStateCount("FAIL", 1);
+            groupedLogs.add(e);
+        }
+
+        for (int i = 0; i < yesterdayDiscard; i++) {
+            QuestStatisticsResponse e = new QuestStatisticsResponse(yesterday);
+            e.addStateCount("DISCARD", 1);
+            groupedLogs.add(e);
+        }
+
+        for (int i = 0; i < todayComplete; i++) {
+            QuestStatisticsResponse e = new QuestStatisticsResponse(today);
+            e.addStateCount("COMPLETE", 1);
+            groupedLogs.add(e);
+        }
+
+        for (int i = 0; i < todayMain; i++) {
+            QuestStatisticsResponse e = new QuestStatisticsResponse(today);
+            e.addTypeCount("MAIN", 1);
+            groupedLogs.add(e);
+        }
+
+        QuestLogSearchCondition condition = new QuestLogSearchCondition(QuestLogSearchType.DAILY, today);
+        doReturn(groupedLogs).when(questLogRepository).getGroupedQuestLogs(any(), eq(condition));
+
+        //when
+        Map<LocalDate, QuestStatisticsResponse> questStatistic = questLogService.getQuestStatistic(1L, condition);
+
+        //then
+        verify(questLogRepository, times(1)).getGroupedQuestLogs(eq(1L), eq(condition));
+
+        assertThat(questStatistic.keySet().size()).isEqualTo(today.lengthOfMonth());
+
+        assertThat(questStatistic.get(today).getCompleteCount()).isEqualTo(todayComplete);
+
+        assertThat(questStatistic.get(yesterday).getFailCount()).isEqualTo(yesterdayFail);
+        assertThat(questStatistic.get(yesterday).getDiscardCount()).isEqualTo(yesterdayDiscard);
+        assertThat(questStatistic.get(yesterday).getCompleteCount()).isEqualTo(yesterdayComplete);
+
+        assertThat(questStatistic.get(today).getMainCount()).isEqualTo(todayMain);
+
+        assertThat(questStatistic.get(today).getSubCount()).isEqualTo(0);
+        assertThat(questStatistic.get(today).getFailCount()).isEqualTo(0);
+        assertThat(questStatistic.get(today).getDiscardCount()).isEqualTo(0);
+
+        assertThat(questStatistic.get(today).getTypeRatio()).isEqualTo(100);
+        assertThat(questStatistic.get(today).getStateRatio()).isEqualTo(100);
+    }
+
+
+}


### PR DESCRIPTION
퀘스트 로그 응답 DTO 추가
퀘스트 로그 리포지토리를 통한 조회 시 DTO를 반환하도록 변경해 결합도 감소
퀘스트 로그 서비스를 통한 조회 시 계산 로직을 DTO 내부로 이동
요청 조건에 따라 응답에 필요한 맵을 생성하는 로직을 요청 DTO에 추가
테스트 코드 추가 및 TimeUtil 테스트 코드 수정