### PR TITLE
test: JWT 도메인 관련 테스트 코드 작성

### DIFF
--- a/src/main/java/dailyquest/common/GoogleIdTokenVerifierFactory.java
+++ b/src/main/java/dailyquest/common/GoogleIdTokenVerifierFactory.java
@@ -1,0 +1,17 @@
+package dailyquest.common;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+@Component
+public class GoogleIdTokenVerifierFactory {
+    public GoogleIdTokenVerifier create(HttpTransport transport, JsonFactory jsonFactory, Collection<String> audience) {
+        return new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
+                .setAudience(audience)
+                .build();
+    }
+}

--- a/src/main/java/dailyquest/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/dailyquest/jwt/JwtAuthorizationFilter.java
@@ -1,5 +1,8 @@
 package dailyquest.jwt;
 
+import dailyquest.properties.SecurityUrlProperties;
+import dailyquest.user.dto.UserPrincipal;
+import dailyquest.user.service.UserService;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -9,12 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
-import dailyquest.properties.SecurityUrlProperties;
-import dailyquest.user.service.UserService;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -52,7 +52,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
             Long userId = jwtTokenProvider.getUserIdFromToken(accessToken);
 
-            UserDetails userDetails = userService.getUserById(userId);
+            UserPrincipal userDetails = userService.getUserById(userId);
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/dailyquest/jwt/JwtTokenProvider.java
+++ b/src/main/java/dailyquest/jwt/JwtTokenProvider.java
@@ -129,12 +129,12 @@ public class JwtTokenProvider {
     }
 
     public Pair<Cookie, Cookie> invalidateToken(@Nullable Cookie[] cookies) throws ExpiredJwtException {
-        String refreshToken = getJwtFromCookies(cookies, REFRESH_TOKEN_NAME);
 
         // 토큰 만료 시 블랙 리스트 추가 불필요
         try {
+            String refreshToken = getJwtFromCookies(cookies, REFRESH_TOKEN_NAME);
             addToBlackList(refreshToken);
-        } catch (ExpiredJwtException ignored) {
+        } catch (JwtException ignored) {
         }
 
         Cookie emptyAccessToken = new Cookie(JwtTokenProvider.ACCESS_TOKEN_NAME, "");

--- a/src/test/java/dailyquest/jwt/JwtAuthorizationFilterUnitTest.java
+++ b/src/test/java/dailyquest/jwt/JwtAuthorizationFilterUnitTest.java
@@ -1,0 +1,135 @@
+package dailyquest.jwt;
+
+import dailyquest.properties.SecurityUrlProperties;
+import dailyquest.user.dto.UserPrincipal;
+import dailyquest.user.service.UserService;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.Cookie;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtAuthorizationFilter 유닛 테스트")
+public class JwtAuthorizationFilterUnitTest {
+
+    @MockBean
+    static MockMvc mvc;
+    static JwtTokenProvider jwtTokenProvider;
+    static UserService userService;
+    static SecurityUrlProperties securityUrlProperties;
+
+    @BeforeAll
+    static void init() {
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+        userService = mock(UserService.class);
+        securityUrlProperties = mock(SecurityUrlProperties.class);
+
+        JwtAuthorizationFilter jwtAuthorizationFilter = new JwtAuthorizationFilter(jwtTokenProvider, userService, securityUrlProperties);
+        mvc = MockMvcBuilders.standaloneSetup().addFilter(jwtAuthorizationFilter).build();
+    }
+
+    @DisplayName("인가가 필요없는 요청 url 일 경우 필터 로직을 건너뛴다")
+    @Test
+    public void doesNotCheckAllowedUrl() throws Exception {
+        //given
+        String[] allowedUrl = {"/allowed"};
+        doReturn(allowedUrl).when(securityUrlProperties).getAllowedUrl();
+
+        //when
+        mvc.perform(get(allowedUrl[0]));
+
+        //then
+        verifyNoInteractions(jwtTokenProvider, userService);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @DisplayName("토큰 조회 및 처리 실패 시 401 에러 리스폰스를 반환한다")
+    @Test
+    public void sendErrorWhenFailToGetToken() throws Exception {
+        //given
+        String url = "/someurl";
+        doReturn(new String[]{"/allowed"}).when(securityUrlProperties).getAllowedUrl();
+
+        doThrow(new JwtException("")).when(jwtTokenProvider).getJwtFromCookies(any(), any());
+
+        //when
+        MockHttpServletResponse response = mvc.perform(get(url))
+                .andReturn()
+                .getResponse();
+
+        //then
+        verify(jwtTokenProvider, never()).getUserIdFromToken(any());
+        verifyNoInteractions(userService);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @DisplayName("토큰이 만료된 경우 사일런트 리프레쉬를 수행한다")
+    @Test
+    public void doSilentRefreshWhenExpiredToken() throws Exception {
+        //given
+        String url = "/someurl";
+        doReturn(new String[]{"/allowed"}).when(securityUrlProperties).getAllowedUrl();
+        doReturn(false).when(jwtTokenProvider).isValidToken(any(), any());
+
+        Cookie mockCookie = mock(Cookie.class);
+        doReturn(mockCookie).when(jwtTokenProvider).createAccessTokenCookie(any());
+        doReturn(mockCookie).when(jwtTokenProvider).createRefreshTokenCookie(any());
+
+        UserPrincipal mockUserDetail = mock(UserPrincipal.class);
+        doReturn(mockUserDetail).when(userService).getUserById(any());
+
+        //when
+        mvc.perform(get(url));
+
+        //then
+        verify(jwtTokenProvider, times(1)).getJwtFromCookies(any(), eq(JwtTokenProvider.REFRESH_TOKEN_NAME));
+        verify(jwtTokenProvider, times(1)).silentRefresh(any());
+        verify(jwtTokenProvider, times(1)).createAccessTokenCookie(any());
+        verify(jwtTokenProvider, times(1)).createRefreshToken(any());
+        assertThat(SecurityContextHolder.getContext().getAuthentication().isAuthenticated()).isTrue();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(mockUserDetail);
+    }
+
+    @DisplayName("인증에 성공한 경우 Authentication 정보를 등록한다")
+    @Test
+    public void setAuthenticationWhenSuccess() throws Exception {
+        //given
+        String url = "/someurl";
+        doReturn(new String[]{"/allowed"}).when(securityUrlProperties).getAllowedUrl();
+        doReturn(true).when(jwtTokenProvider).isValidToken(any(), any());
+
+        Cookie mockCookie = mock(Cookie.class);
+        doReturn(mockCookie).when(jwtTokenProvider).createAccessTokenCookie(any());
+        doReturn(mockCookie).when(jwtTokenProvider).createRefreshTokenCookie(any());
+
+        UserPrincipal mockUserDetail = mock(UserPrincipal.class);
+        doReturn(mockUserDetail).when(userService).getUserById(any());
+
+        //when
+        mvc.perform(get(url));
+
+        //then
+        verify(jwtTokenProvider, never()).getJwtFromCookies(any(), eq(JwtTokenProvider.REFRESH_TOKEN_NAME));
+        verify(jwtTokenProvider, never()).silentRefresh(any());
+        verify(jwtTokenProvider, never()).createAccessTokenCookie(any());
+        verify(jwtTokenProvider, never()).createRefreshToken(any());
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication().isAuthenticated()).isTrue();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(mockUserDetail);
+    }
+
+}

--- a/src/test/java/dailyquest/jwt/JwtTokenProviderUnitTest.java
+++ b/src/test/java/dailyquest/jwt/JwtTokenProviderUnitTest.java
@@ -1,0 +1,468 @@
+package dailyquest.jwt;
+
+import dailyquest.common.MessageUtil;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import jakarta.servlet.http.Cookie;
+import kotlin.Pair;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.time.Duration;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JWT 토큰 프로바이더 단위 테스트")
+public class JwtTokenProviderUnitTest {
+
+    @Mock
+    RedisTemplate<String, String> redisTemplate;
+
+    @InjectMocks
+    JwtTokenProvider jwtTokenProvider;
+
+    String secretKey = "and0LWF1dGhlbnRpY2F0aW9uLWZpbHRlci10ZXN0LXNlY3JldC1rZXQtMDAwMA==";
+    String anotherKey = "xxand0LWF1dGhlbnRpY2F0aW9uLWZpbHRlci10ZXN0LXNlY3JldC1rZXQtMDAwMA==";
+
+    static MockedStatic<MessageUtil> messageUtil;
+
+    @BeforeAll
+    static void beforeAll() {
+        messageUtil = mockStatic(MessageUtil.class);
+        when(MessageUtil.getMessage(any())).thenReturn("");
+        when(MessageUtil.getMessage(any(), any())).thenReturn("");
+    }
+
+    @BeforeEach
+    void before() {
+        ReflectionTestUtils.setField(jwtTokenProvider, "secretKey", secretKey);
+    }
+
+
+    @DisplayName("createAccessToken 요청 시")
+    @Nested
+    class TestCreateAccessToken {
+
+        @DisplayName("반환된 토큰에 파라미터에 전달된 ID가 포함되어야 한다")
+        @Test
+        public void haveToIncludeId() throws Exception {
+            //given
+            Long userId = 3L;
+
+            //when
+            String accessToken = jwtTokenProvider.createAccessToken(userId);
+
+            //then
+            Long userIdFromToken = jwtTokenProvider.getUserIdFromToken(accessToken);
+            assertThat(userId).isEqualTo(userIdFromToken);
+        }
+        
+        @DisplayName("반환된 토큰 타입이 엑세스 토큰이어야 한다")
+        @Test
+        public void haveToBeAccessToken() throws Exception {
+            //given
+            Long userId = 5L;
+
+            //when
+            String accessToken = jwtTokenProvider.createAccessToken(userId);
+
+            //then
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(Decoders.BASE64.decode(secretKey))
+                    .build()
+                    .parseClaimsJws(accessToken);
+
+            Claims body = claims.getBody();
+            String token_type = body.get("token_type", String.class);
+
+            assertThat(token_type).isEqualTo(JwtTokenProvider.ACCESS_TOKEN_NAME);
+        }
+
+        @DisplayName("올바른 시크릿 키를 사용해서 생성된 토큰이 반환되야 한다")
+        @Test
+        public void haveToUseValidSecretKey() throws Exception {
+            //given
+            Long userId = 1L;
+            JwtParser invalidParser = Jwts.parserBuilder()
+                    .setSigningKey(Decoders.BASE64.decode(anotherKey))
+                    .build();
+            JwtParser validParser = Jwts.parserBuilder()
+                    .setSigningKey(Decoders.BASE64.decode(secretKey))
+                    .build();
+
+            //when
+            String accessToken = jwtTokenProvider.createAccessToken(userId);
+
+            //then
+            Runnable invalidRun = () -> invalidParser.parseClaimsJws(accessToken);
+            Runnable validRun = () -> validParser.parseClaimsJws(accessToken);
+
+            assertThatThrownBy(invalidRun::run);
+            assertDoesNotThrow(validRun::run);
+        }
+
+        @DisplayName("토큰 생성 시간이 요청 시간이며 올바른 만료 시간이 지정돼야 한다")
+        @Test
+        public void haveToBeCreatedAtInvoked() throws Exception {
+            //given
+            Long userId = 9L;
+            Date now = new Date();
+            Date expiredDate = new Date(now.getTime() + JwtTokenProvider.ACCESS_TOKEN_VALIDATION_MILLISECOND);
+
+            //when
+            String accessToken = jwtTokenProvider.createAccessToken(userId);
+
+            //then
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(Decoders.BASE64.decode(secretKey))
+                    .build()
+                    .parseClaimsJws(accessToken);
+
+            Claims body = claims.getBody();
+
+            Date issuedAt = body.getIssuedAt();
+            Date expiration = body.getExpiration();
+
+            assertThat(issuedAt).isCloseTo(now, 1000 * 10);
+            assertThat(expiration).isCloseTo(expiredDate, 1000 * 10);
+        }
+    }
+
+    @DisplayName("createRefreshToken 요청 시")
+    @Nested
+    class TestCreateRefreshToken {
+        @DisplayName("반환된 토큰에 파라미터에 전달된 ID가 포함되어야 한다")
+        @Test
+        public void haveToIncludeId() throws Exception {
+            //given
+            Long userId = 3L;
+
+            //when
+            String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+            //then
+            Long userIdFromToken = jwtTokenProvider.getUserIdFromToken(refreshToken);
+            assertThat(userId).isEqualTo(userIdFromToken);
+        }
+
+        @DisplayName("반환된 토큰 타입이 리프레시 토큰이어야 한다")
+        @Test
+        public void haveToBeRefreshToken() throws Exception {
+            //given
+            Long userId = 5L;
+
+            //when
+            String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+            //then
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(Decoders.BASE64.decode(secretKey))
+                    .build()
+                    .parseClaimsJws(refreshToken);
+
+            Claims body = claims.getBody();
+            String token_type = body.get("token_type", String.class);
+
+            assertThat(token_type).isEqualTo(JwtTokenProvider.REFRESH_TOKEN_NAME);
+        }
+
+        @DisplayName("올바른 시크릿 키를 사용해서 생성된 토큰이 반환되야 한다")
+        @Test
+        public void haveToUseValidSecretKey() throws Exception {
+            //given
+            Long userId = 1L;
+            JwtParser invalidParser = Jwts.parserBuilder()
+                    .setSigningKey(Decoders.BASE64.decode(anotherKey))
+                    .build();
+            JwtParser validParser = Jwts.parserBuilder()
+                    .setSigningKey(Decoders.BASE64.decode(secretKey))
+                    .build();
+
+            //when
+            String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+            //then
+            Runnable invalidRun = () -> invalidParser.parseClaimsJws(refreshToken);
+            Runnable validRun = () -> validParser.parseClaimsJws(refreshToken);
+
+            assertThatThrownBy(invalidRun::run);
+            assertDoesNotThrow(validRun::run);
+        }
+
+        @DisplayName("토큰 생성 시간이 요청 시간이며 올바른 만료 시간이 지정돼야 한다")
+        @Test
+        public void haveToBeCreatedAtInvoked() throws Exception {
+            //given
+            Long userId = 9L;
+            Date now = new Date();
+            Date expiredDate = new Date(now.getTime() + JwtTokenProvider.REFRESH_TOKEN_VALIDATION_MILLISECOND);
+
+            //when
+            String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+            //then
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(Decoders.BASE64.decode(secretKey))
+                    .build()
+                    .parseClaimsJws(refreshToken);
+
+            Claims body = claims.getBody();
+
+            Date issuedAt = body.getIssuedAt();
+            Date expiration = body.getExpiration();
+
+            assertThat(issuedAt).isCloseTo(now, 1000 * 10);
+            assertThat(expiration).isCloseTo(expiredDate, 1000 * 10);
+        }
+    }
+
+
+    @DisplayName("isValidToken 요청 시")
+    @Nested
+    class IsValidTokenTest {
+        @DisplayName("유효하지 않은 토큰일 경우 false가 반환된다")
+        @Test
+        public void doReturnFalseWhenInvalid() throws Exception {
+            //given
+            String invalidSecretKey = "asdsadqwlkdqnmlkqw===1=as12e21==134124adasd12==4214=";
+            String invalidToken = Jwts.builder()
+                    .claim("token_type", JwtTokenProvider.REFRESH_TOKEN_NAME)
+                    .signWith(new SecretKeySpec(Decoders.BASE64.decode(invalidSecretKey), SignatureAlgorithm.HS256.getJcaName()))
+                    .compact();
+
+            //when
+            boolean isValidToken = jwtTokenProvider.isValidToken(invalidToken, JwtTokenProvider.REFRESH_TOKEN_NAME);
+
+            //then
+            assertThat(isValidToken).isFalse();
+        }
+
+        @DisplayName("요청 타입과 실제 타입이 다를 경우 false 를 반환한다")
+        @Test
+        public void doReturnFalseWhenIncorrectType() throws Exception {
+            //given
+            String validToken = jwtTokenProvider.createRefreshToken(1L);
+
+            //when
+            boolean isValidToken = jwtTokenProvider.isValidToken(validToken, JwtTokenProvider.ACCESS_TOKEN_NAME);
+
+            //then
+            assertThat(isValidToken).isFalse();
+        }
+
+        @DisplayName("만료된 토큰일 경우 false 를 반환한다")
+        @Test
+        public void doReturnFalseWhenExpired() throws Exception {
+            //given
+            String expiredToken = Jwts.builder()
+                    .claim("token_type", JwtTokenProvider.REFRESH_TOKEN_NAME)
+                    .setExpiration(new Date())
+                    .signWith(new SecretKeySpec(Decoders.BASE64.decode(secretKey), SignatureAlgorithm.HS256.getJcaName()))
+                    .compact();
+
+            //when
+            boolean isValidToken = jwtTokenProvider.isValidToken(expiredToken, JwtTokenProvider.REFRESH_TOKEN_NAME);
+
+            //then
+            assertThat(isValidToken).isFalse();
+        }
+        
+        @DisplayName("유효한 토큰일 경우 true가 반환된다")
+        @Test
+        public void doReturnTrueWhenValid() throws Exception {
+            //given
+            String validToken = jwtTokenProvider.createRefreshToken(1L);
+
+            //when
+            boolean isValidToken = jwtTokenProvider.isValidToken(validToken, JwtTokenProvider.REFRESH_TOKEN_NAME);
+
+            //then
+            assertThat(isValidToken).isTrue();
+        }
+    }
+
+    @DisplayName("createAccessTokenCookie 요청 시 httpOnly, path=/ 인 쿠키가 반환된다")
+    @Test
+    public void testCreateAccessTokenCookie() throws Exception {
+        //given
+        String accessToken = jwtTokenProvider.createAccessToken(1L);
+
+        //when
+        Cookie accessTokenCookie = jwtTokenProvider.createAccessTokenCookie(accessToken);
+
+        //then
+        assertThat(accessTokenCookie.isHttpOnly()).isTrue();
+        assertThat(accessTokenCookie.getPath()).isEqualTo("/");
+    }
+    
+    @DisplayName("createRefreshTokenCookie 요청 시 httpOnly, path=/ 인 쿠키가 반환된다")
+    @Test
+    public void testCreateRefreshTokenCookie() throws Exception {
+        //given
+        String refreshToken = jwtTokenProvider.createRefreshToken(1L);
+
+        //when
+        Cookie refreshTokenCookie = jwtTokenProvider.createRefreshTokenCookie(refreshToken);
+
+        //then
+        assertThat(refreshTokenCookie.isHttpOnly()).isTrue();
+        assertThat(refreshTokenCookie.getPath()).isEqualTo("/");
+    }
+
+    @DisplayName("silentRefresh 요청 시")
+    @Nested
+    class SilentRefreshTest {
+        @DisplayName("요청에 사용된 리프레시 토큰이 블랙 리스트에 포함된 토큰이라면 예외를 던진다")
+        @Test
+        public void doThrowWhenInBlackList() throws Exception {
+            //given
+            ValueOperations<String, String> mockOperation = mock(ValueOperations.class);
+            doReturn(mockOperation).when(redisTemplate).opsForValue();
+            doReturn("in black list").when(mockOperation).get(any());
+
+            String token = jwtTokenProvider.createRefreshToken(1L);
+
+            //when
+            Runnable runnable = () -> jwtTokenProvider.silentRefresh(token);
+
+            //then
+            assertThatThrownBy(runnable::run).isInstanceOf(JwtException.class);
+        }
+
+        @DisplayName("유효하지 않은 토큰이라면 예외를 던진다")
+        @Test
+        public void doThrowWhenInvalidToken() throws Exception {
+            //given
+            ValueOperations<String, String> mockOperation = mock(ValueOperations.class);
+            doReturn(mockOperation).when(redisTemplate).opsForValue();
+            doReturn(null).when(mockOperation).get(any());
+
+            String invalidSecretKey = "asdsadqwlkdqnmlkqw===1=as12e21==134124adasd12==4214=";
+            String invalidToken = Jwts.builder()
+                    .claim("token_type", JwtTokenProvider.REFRESH_TOKEN_NAME)
+                    .signWith(new SecretKeySpec(Decoders.BASE64.decode(invalidSecretKey), SignatureAlgorithm.HS256.getJcaName()))
+                    .compact();
+
+            //when
+            Runnable runnable = () -> jwtTokenProvider.silentRefresh(invalidToken);
+
+            //then
+            assertThatThrownBy(runnable::run).isInstanceOf(JwtException.class);
+        }
+
+        @DisplayName("유효한 토큰이라면 리프레시 토큰을 블랙 리스트 처리 후 새 엑세스 토큰을 반환한다")
+        @Test
+        public void doRefresh() throws Exception {
+            //given
+            ValueOperations<String, String> mockOperation = mock(ValueOperations.class);
+            doReturn(mockOperation).when(redisTemplate).opsForValue();
+            doReturn(null).when(mockOperation).get(any());
+
+            String token = jwtTokenProvider.createRefreshToken(1L);
+
+            //when
+            String newToken = jwtTokenProvider.silentRefresh(token);
+
+            //then
+            verify(mockOperation).set(eq(token), eq(""), any(Duration.class));
+            assertThat(newToken).isNotEmpty();
+            assertThat(newToken).isNotEqualTo(token);
+        }
+    }
+    @DisplayName("토큰 invalidate 요청 시")
+    @Nested
+    class TokenInvalidateTest {
+
+        @DisplayName("이미 만료된 토큰일 경우 빈 토큰을 반환한다")
+        @Test
+        public void doReturnEmptyTokenWhenExpired() throws Exception {
+            //given
+            String expiredRefreshToken = Jwts.builder()
+                    .claim("token_type", JwtTokenProvider.REFRESH_TOKEN_NAME)
+                    .setExpiration(new Date())
+                    .signWith(new SecretKeySpec(Decoders.BASE64.decode(secretKey), SignatureAlgorithm.HS256.getJcaName()))
+                    .compact();
+
+            Cookie[] cookies = new Cookie[]{jwtTokenProvider.createRefreshTokenCookie(expiredRefreshToken)};
+
+            //when
+            Pair<Cookie, Cookie> emptyCookies = jwtTokenProvider.invalidateToken(cookies);
+
+            //then
+            verify(redisTemplate, never()).opsForValue();
+            assertThat(emptyCookies.getFirst().getMaxAge()).isEqualTo(0);
+            assertThat(emptyCookies.getFirst().getValue()).isEmpty();
+            assertThat(emptyCookies.getSecond().getMaxAge()).isEqualTo(0);
+            assertThat(emptyCookies.getSecond().getValue()).isEmpty();
+        }
+
+        @DisplayName("리프레쉬 토큰을 레디스 블랙 리스트에 등록한다")
+        @Test
+        public void doSaveOnRedis() throws Exception {
+            //given
+            String refreshToken = jwtTokenProvider.createRefreshToken(1L);
+            Cookie[] cookies = new Cookie[]{jwtTokenProvider.createRefreshTokenCookie(refreshToken)};
+
+            ValueOperations<String, String> mockOperation = mock(ValueOperations.class);
+            doReturn(mockOperation).when(redisTemplate).opsForValue();
+
+            //when
+            jwtTokenProvider.invalidateToken(cookies);
+
+            //then
+            verify(mockOperation).set(eq(refreshToken), eq(""), any(Duration.class));
+        }
+
+        @DisplayName("레디스에 등록된 토큰에 토큰 만료 시간만큼의 TTL이 등록된다")
+        @Test
+        public void doSetTTLOnRedis() throws Exception {
+            //given
+            ValueOperations<String, String> mockOperation = mock(ValueOperations.class);
+            doReturn(mockOperation).when(redisTemplate).opsForValue();
+
+            String refreshToken = jwtTokenProvider.createRefreshToken(1L);
+            Cookie[] cookies = new Cookie[]{jwtTokenProvider.createRefreshTokenCookie(refreshToken)};
+
+            Date expiredDate = jwtTokenProvider.getExpiredDateFromToken(refreshToken);
+            long now = new Date().toInstant().getEpochSecond();
+            Duration timeout = Duration.ofSeconds(expiredDate.toInstant().getEpochSecond() - now);
+
+            ArgumentCaptor<Duration> durationCaptor = ArgumentCaptor.forClass(Duration.class);
+
+            //when
+            jwtTokenProvider.invalidateToken(cookies);
+
+            //then
+            verify(mockOperation).set(eq(refreshToken), eq(""), durationCaptor.capture());
+            assertThat(durationCaptor.getValue()).isCloseTo(timeout, Duration.ofSeconds(600));
+        }
+
+        @DisplayName("쿠키에 토큰 정보가 없을 경우 예외를 던지지 않고 빈 토큰을 반환한다")
+        @Test
+        public void doesNotThrowWhenTokenNull() throws Exception {
+            //given
+            Cookie[] cookies = null;
+
+            //when
+            Runnable run = () -> jwtTokenProvider.invalidateToken(cookies);
+
+            //then
+            assertDoesNotThrow(run::run);
+        }
+
+    }
+}

--- a/src/test/java/dailyquest/jwt/controller/JwtControllerUnitTest.java
+++ b/src/test/java/dailyquest/jwt/controller/JwtControllerUnitTest.java
@@ -1,0 +1,161 @@
+package dailyquest.jwt.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dailyquest.annotation.WithCustomMockUser;
+import dailyquest.config.SecurityConfig;
+import dailyquest.jwt.JwtAuthorizationFilter;
+import dailyquest.jwt.dto.TokenRequest;
+import dailyquest.jwt.service.JwtService;
+import dailyquest.user.entity.ProviderType;
+import jakarta.servlet.http.Cookie;
+import kotlin.Pair;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@SuppressWarnings("ALL")
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(controllers = JwtController.class,
+        excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthorizationFilter.class})})
+@WithCustomMockUser
+@DisplayName("JWT 컨트롤러 유닛 테스트")
+public class JwtControllerUnitTest {
+    static final String URI_PREFIX = "/api/v1/auth";
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    JwtService jwtService;
+
+    static ObjectMapper om;
+
+    @BeforeAll
+    static void init() {
+        om = new ObjectMapper();
+        om.registerModule(new JavaTimeModule());
+    }
+
+    @DisplayName("POST /issue 요청 시")
+    @Nested
+    class TestIssue {
+        @DisplayName("요청 정보를 issueTokenCookie 요청에 위임한다")
+        @Test
+        public void delegateRequest() throws Exception {
+            //given
+            String url = URI_PREFIX + "/issue";
+            String idToken = "idToken";
+            ProviderType providerType = ProviderType.GOOGLE;
+            TokenRequest mockRequest = new TokenRequest(idToken, providerType);
+
+            Pair<Cookie, Cookie> mockPair = mock(Pair.class);
+            doReturn(mockPair).when(jwtService).issueTokenCookie(eq(mockRequest));
+
+            //when
+            mvc.perform(
+                    post(url)
+                            .with(csrf())
+                            .content(om.writeValueAsBytes(mockRequest))
+                            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            );
+
+            //then
+            verify(jwtService).issueTokenCookie(eq(mockRequest));
+        }
+
+        @DisplayName("리스폰스에 쿠키를 담아 반환한다")
+        @Test
+        public void doReturnCookie() throws Exception {
+            //given
+            String url = URI_PREFIX + "/issue";
+
+            String idToken = "idToken";
+            ProviderType providerType = ProviderType.GOOGLE;
+            TokenRequest mockRequest = new TokenRequest(idToken, providerType);
+
+            Cookie access = mock(Cookie.class);
+            Cookie refresh = mock(Cookie.class);
+
+            Pair<Cookie, Cookie> pair = new Pair<>(access, refresh);
+            doReturn(pair).when(jwtService).issueTokenCookie(eq(mockRequest));
+
+            //when
+            MockHttpServletResponse response = mvc.perform(
+                            post(url)
+                                    .with(csrf())
+                                    .content(om.writeValueAsBytes(mockRequest))
+                                    .contentType(MediaType.APPLICATION_JSON_UTF8)
+                    ).andReturn()
+                    .getResponse();
+
+            //then
+            assertThat(response.getCookies()).contains(access, refresh);
+        }
+
+    }
+
+    @DisplayName("POST /logout 요청 시")
+    @Nested
+    class TestLogout {
+        @DisplayName("invalidateToken 메서드에 요청을 위임한다")
+        @Test
+        public void delegateTo() throws Exception {
+            //given
+            String url = URI_PREFIX + "/logout";
+
+            Pair<Cookie, Cookie> mockPair = mock(Pair.class);
+            doReturn(mockPair).when(jwtService).invalidateToken(any());
+
+            //when
+            mvc.perform(
+                    post(url)
+                            .with(csrf())
+            );
+
+            //then
+            verify(jwtService).invalidateToken(any());
+        }
+
+        @DisplayName("response 에 쿠키가 담겨 반환된다")
+        @Test
+        public void returnCookie() throws Exception {
+            //given
+            String url = URI_PREFIX + "/logout";
+
+            Cookie access = mock(Cookie.class);
+            Cookie refresh = mock(Cookie.class);
+
+            Pair<Cookie, Cookie> pair = new Pair<>(access, refresh);
+            doReturn(pair).when(jwtService).invalidateToken(any());
+
+            //when
+            MockHttpServletResponse response = mvc.perform(
+                            post(url)
+                                    .with(csrf())
+                    ).andReturn()
+                    .getResponse();
+
+            //then
+            assertThat(response.getCookies()).contains(access, refresh);
+        }
+    }
+
+}

--- a/src/test/java/dailyquest/jwt/service/JwtServiceUnitTest.java
+++ b/src/test/java/dailyquest/jwt/service/JwtServiceUnitTest.java
@@ -1,0 +1,148 @@
+package dailyquest.jwt.service;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import dailyquest.common.GoogleIdTokenVerifierFactory;
+import dailyquest.common.MessageUtil;
+import dailyquest.jwt.JwtTokenProvider;
+import dailyquest.jwt.dto.TokenRequest;
+import dailyquest.user.dto.UserPrincipal;
+import dailyquest.user.service.UserService;
+import jakarta.servlet.http.Cookie;
+import kotlin.Pair;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JWT 서비스 유닛 테스트")
+public class JwtServiceUnitTest {
+
+    static JwtService jwtService;
+    static JwtTokenProvider jwtTokenProvider;
+    static UserService userService;
+    static GoogleIdTokenVerifierFactory verifierFactory;
+    static String clientId = "test-client-id";
+    static MockedStatic<MessageUtil> messageUtil;
+
+    @BeforeAll
+    static void before() {
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+        userService = mock(UserService.class);
+        verifierFactory = mock(GoogleIdTokenVerifierFactory.class);
+        jwtService = new JwtService(clientId, jwtTokenProvider, userService, verifierFactory);
+
+        messageUtil = mockStatic(MessageUtil.class);
+        when(MessageUtil.getMessage(any())).thenReturn("");
+        when(MessageUtil.getMessage(any(), any())).thenReturn("");
+    }
+
+    @DisplayName("issueTokenCookie 요청 시")
+    @Nested
+    class TestIssueTokenCookie {
+        @DisplayName("idToken 이 null 이라면 AccessDenied 예외를 던진다")
+        @Test
+        public void throwAccessDeniedWhenIdTokenIsNull() throws Exception {
+            //given
+            TokenRequest mockRequest = mock(TokenRequest.class);
+
+            //when
+            Runnable run = () -> jwtService.issueTokenCookie(mockRequest);
+
+            //then
+            assertThatThrownBy(run::run).isInstanceOf(AccessDeniedException.class);
+        }
+
+        @DisplayName("verify 실패 시 AccessDenied 예외를 던진다")
+        @Test
+        public void throwAccessDeniedWhenVerifyFailed() throws Exception {
+            //given
+            TokenRequest mockRequest = mock(TokenRequest.class);
+            String idToken = "id-token";
+            doReturn(idToken).when(mockRequest).getIdToken();
+
+            GoogleIdTokenVerifier mockVerifier = mock(GoogleIdTokenVerifier.class);
+            doReturn(mockVerifier).when(verifierFactory).create(any(), any(), any());
+            doThrow(new RuntimeException()).when(mockVerifier).verify(eq(idToken));
+
+            //when
+            Runnable run = () -> jwtService.issueTokenCookie(mockRequest);
+
+            //then
+            assertThatThrownBy(run::run).isInstanceOf(AccessDeniedException.class);
+        }
+
+        @DisplayName("idToken이 유효하다면 유저 정보 등록 or 조회 후 토큰을 생성해 반환한다")
+        @Test
+        public void doRegisterOrGetUserAndReturn() throws Exception {
+            //given
+            TokenRequest mockRequest = mock(TokenRequest.class);
+
+            String rawIdToken = "id-token";
+            doReturn(rawIdToken).when(mockRequest).getIdToken();
+
+            GoogleIdTokenVerifier mockVerifier = mock(GoogleIdTokenVerifier.class);
+            doReturn(mockVerifier).when(verifierFactory).create(any(), any(), any());
+
+            GoogleIdToken mockIdToken = mock(GoogleIdToken.class);
+            doReturn(mockIdToken).when(mockVerifier).verify(eq(rawIdToken));
+
+            GoogleIdToken.Payload mockPayload = mock(GoogleIdToken.Payload.class);
+            doReturn(mockPayload).when(mockIdToken).getPayload();
+
+            UserPrincipal mockUser = mock(UserPrincipal.class);
+            doReturn(mockUser).when(userService).getOrRegisterUser(any(), any());
+
+            String accessToken = "access";
+            String refreshToken = "refresh";
+
+            doReturn(accessToken).when(jwtTokenProvider).createAccessToken(any());
+            doReturn(refreshToken).when(jwtTokenProvider).createRefreshToken(any());
+
+            //when
+            jwtService.issueTokenCookie(mockRequest);
+
+            //then
+            verify(userService).getOrRegisterUser(any(), any());
+
+            verify(jwtTokenProvider).createAccessToken(any());
+            verify(jwtTokenProvider).createRefreshToken(any());
+
+            verify(jwtTokenProvider).createAccessTokenCookie(eq(accessToken));
+            verify(jwtTokenProvider).createRefreshTokenCookie(eq(refreshToken));
+        }
+
+    }
+
+    @DisplayName("invalidateToken 요청 시")
+    @Nested
+    class TestInvalidateToken {
+        @DisplayName("인자로 넘어온 쿠키로 요청을 위임한다")
+        @Test
+        public void passParameterTo() throws Exception {
+            //given
+            Cookie mockCookie = mock(Cookie.class);
+            Cookie[] cookies = new Cookie[]{mockCookie};
+
+            Pair mockPair = mock(Pair.class);
+            doReturn(mockPair).when(jwtTokenProvider).invalidateToken(any());
+
+            //when
+            jwtService.invalidateToken(cookies);
+
+            //then
+            verify(jwtTokenProvider).invalidateToken(eq(cookies));
+        }
+
+    }
+
+}


### PR DESCRIPTION
- 테스트가 불가능해서 GoogleIdTokenVerifier를 Factory 를 통해 생성하도록 변경
- idToken verify 시 오류가 발생하면 null로 처리하도록 변경
- 토큰 invalidate 메서드에서 토큰 정보 조회 오류 발생 시 빈 토큰만 반환하도록 변경