### PR TITLE
feat: 엘라스틱서치 검색 시 검색 조건 추가

### DIFF
--- a/src/main/java/dailyquest/quest/controller/QuestApiController.java
+++ b/src/main/java/dailyquest/quest/controller/QuestApiController.java
@@ -1,5 +1,6 @@
 package dailyquest.quest.controller;
 
+import dailyquest.quest.entity.QuestState;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -35,10 +36,10 @@ public class QuestApiController {
 
     @GetMapping("")
     public ResponseEntity<ResponseData<List<QuestResponse>>> getQuestList(
-            @Valid QuestSearchCondition condition,
+            QuestState state,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        List<QuestResponse> questList = questService.getCurrentQuests(principal.getId(), condition.state());
+        List<QuestResponse> questList = questService.getCurrentQuests(principal.getId(), state);
         return ResponseEntity.ok(new ResponseData<>(questList));
     }
 

--- a/src/main/java/dailyquest/quest/dto/QuestSearchKeywordType.java
+++ b/src/main/java/dailyquest/quest/dto/QuestSearchKeywordType.java
@@ -1,21 +1,23 @@
 package dailyquest.quest.dto;
 
-public enum QuestSearchKeywordType {
-    ALL(new String[]{FieldType.TITLE, FieldType.DESCRIPTION, FieldType.DETAIL_TITLES}),
-    TITLE(new String[]{FieldType.TITLE}),
-    TITLE_AND_DESCRIPTION(new String[]{FieldType.TITLE, FieldType.DESCRIPTION}),
-    DESCRIPTION(new String[]{FieldType.DESCRIPTION}),
-    DETAIL_TITLES(new String[]{FieldType.DETAIL_TITLES});
+import java.util.List;
 
-    public final String[] fieldNames;
+public enum QuestSearchKeywordType {
+    ALL(List.of(FieldType.TITLE, FieldType.DESCRIPTION, FieldType.DETAIL_TITLES)),
+    TITLE(List.of(FieldType.TITLE)),
+    TITLE_AND_DESCRIPTION(List.of(FieldType.TITLE, FieldType.DESCRIPTION)),
+    DESCRIPTION(List.of(FieldType.DESCRIPTION)),
+    DETAIL_TITLES(List.of(FieldType.DETAIL_TITLES));
+
+    public final List<String> fieldNames;
 
     public static class FieldType {
-        public static final String TITLE = "title";
+        public static final String TITLE = "title^2";
         public static final String DESCRIPTION = "description";
         public static final String DETAIL_TITLES = "detailTitles";
     }
 
-    QuestSearchKeywordType(String[] fieldNames) {
+    QuestSearchKeywordType(List<String> fieldNames) {
         this.fieldNames = fieldNames;
     }
 

--- a/src/main/java/dailyquest/search/document/QuestDocument.java
+++ b/src/main/java/dailyquest/search/document/QuestDocument.java
@@ -3,7 +3,6 @@ package dailyquest.search.document;
 import dailyquest.quest.dto.DetailResponse;
 import dailyquest.quest.dto.QuestResponse;
 import jakarta.persistence.Id;
-import lombok.Getter;
 import org.springframework.data.elasticsearch.annotations.*;
 
 import java.time.LocalDateTime;
@@ -13,32 +12,30 @@ import java.util.List;
 @Setting(settingPath = "elastic/quests/setting.json")
 @Document(indexName = "quests")
 public class QuestDocument {
-    @Getter
     @Id
     private final Long id;
 
     @Field(type = FieldType.Text)
     private final String title;
-
     @Field(type = FieldType.Text)
     private final String description;
-
     @Field(type = FieldType.Text)
     private final List<String> detailTitles;
-
     @Field(type = FieldType.Long)
     private final Long userId;
+    @Field(type = FieldType.Keyword)
+    private final String state;
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    private final LocalDateTime createdDate;
 
-    @Field(type = FieldType.Date)
-    private final LocalDateTime createDate;
-
-    public QuestDocument(Long id, String title, String description, List<String> detailTitles, Long userId, LocalDateTime createDate) {
+    public QuestDocument(Long id, String title, String description, List<String> detailTitles, Long userId, String state, LocalDateTime createdDate) {
         this.id = id;
         this.title = title;
         this.description = description;
         this.detailTitles = detailTitles;
         this.userId = userId;
-        this.createDate = createDate;
+        this.state = state;
+        this.createdDate = createdDate;
     }
 
     public static QuestDocument mapToDocument(QuestResponse questResponse, Long userId) {
@@ -46,7 +43,7 @@ public class QuestDocument {
         if(detailQuests == null) detailQuests = new ArrayList<>();
 
         List<String> detailTitles = detailQuests.stream().map(DetailResponse::getTitle).toList();
-        return new QuestDocument(questResponse.getId(), questResponse.getTitle(), questResponse.getDescription(), detailTitles, userId, questResponse.getCreatedDate());
+        return new QuestDocument(questResponse.getId(), questResponse.getTitle(), questResponse.getDescription(), detailTitles, userId, questResponse.getState().name(), questResponse.getCreatedDate());
     }
 
 }


### PR DESCRIPTION
- Criteria -> Native 쿼리로 변경하고 날짜 범위와 상태 검색 조건 동적으로 추가
- 검색 키워드 타입에 boost 조건 추가하고 멀티 매치용 필드명 리스트로 반환
- 퀘스트 문서 엔티티에 필드 추가 및 날짜 포맷 매핑 추가
- 현재 퀘스트 조회 시 상태 정보만 받도록 변경