### PR TITLE
feat: 공통 모듈 분리를 위한 퀘스트 엔티티 변경

### DIFF
--- a/dailyquest_web/src/main/java/dailyquest/quest/entity/DetailQuest.kt
+++ b/dailyquest_web/src/main/java/dailyquest/quest/entity/DetailQuest.kt
@@ -4,7 +4,6 @@ import jakarta.persistence.*
 import jakarta.persistence.EnumType.*
 import jakarta.persistence.FetchType.*
 import jakarta.persistence.GenerationType.IDENTITY
-import dailyquest.quest.dto.DetailRequest
 
 @Entity
 @Table(name = "detail_quest")
@@ -47,16 +46,16 @@ class DetailQuest(
     @JoinColumn(name = "quest_id")
     val quest: Quest = quest
 
-    fun updateDetailQuest(newDetailQuest: DetailRequest) {
-        title = newDetailQuest.title
-        type = newDetailQuest.type
-        targetCount = if (newDetailQuest.type == DetailQuestType.COUNT) newDetailQuest.targetCount else 1
+    fun updateDetailQuest(id: Long?, detailQuest: DetailQuest) {
+        this.title = detailQuest.title
+        this.type = detailQuest.type
+        this.targetCount = if (type == DetailQuestType.COUNT) detailQuest.targetCount else 1
 
-        if(newDetailQuest.id != this.id || newDetailQuest.type != this.type) resetCount()
+        if(id != this.id || type != this.type) resetCount()
 
-        if(count < targetCount) state = DetailQuestState.PROCEED
+        if(count < targetCount) this.state = DetailQuestState.PROCEED
         else {
-            state = DetailQuestState.COMPLETE
+            this.state = DetailQuestState.COMPLETE
             count = targetCount
         }
 

--- a/dailyquest_web/src/main/java/dailyquest/quest/service/QuestQueryService.java
+++ b/dailyquest_web/src/main/java/dailyquest/quest/service/QuestQueryService.java
@@ -11,6 +11,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,7 +46,7 @@ public class QuestQueryService {
 
     public QuestResponse getQuestInfo(Long questId, Long userId) {
         Quest quest = findByIdOrThrow(questId);
-        quest.checkOwnershipOrThrow(userId);
+        if(!quest.isQuestOfUser(userId)) throw new AccessDeniedException(MessageUtil.getMessage("exception.access.denied"));
 
         return QuestResponse.createDto(quest);
     }

--- a/dailyquest_web/src/test/java/dailyquest/quest/controller/QuestApiControllerTest.kt
+++ b/dailyquest_web/src/test/java/dailyquest/quest/controller/QuestApiControllerTest.kt
@@ -843,8 +843,8 @@ class QuestApiControllerTest @Autowired constructor(
             //given
             val savedQuest = questRepository.save(Quest("제목", "1", testUser, 1L, QuestState.PROCEED, QuestType.MAIN))
 
-            val detailRequest = DetailRequest("detail", DetailQuestType.COUNT, 3)
-            savedQuest.updateDetailQuests(listOf(detailRequest))
+            val detailRequest = DetailQuest("detail", 3, DetailQuestType.COUNT, DetailQuestState.PROCEED, savedQuest)
+            savedQuest.updateDetailQuests(listOf(Pair(null, detailRequest)))
 
             val questId = savedQuest.id
             val url = "${SERVER_ADDR}$port${URI_PREFIX}/$questId"
@@ -1905,8 +1905,8 @@ class QuestApiControllerTest @Autowired constructor(
         @Test
         fun `완료하지 않은 세부 퀘스트가 있다면 BAD_REQUEST가 반환된다`() {
             val savedQuest = questRepository.save(Quest("title", "desc", testUser, 1L, QuestState.PROCEED, QuestType.SUB))
-            val detailRequest = DetailRequest("detail", DetailQuestType.CHECK, 1)
-            savedQuest.updateDetailQuests(listOf(detailRequest))
+            val detailRequest = DetailQuest("detail", 1, DetailQuestType.CHECK, DetailQuestState.PROCEED , savedQuest)
+            savedQuest.updateDetailQuests(listOf(Pair(null, detailRequest)))
 
             val url = "${SERVER_ADDR}$port${URI_PREFIX}/${savedQuest.id}/complete"
             val errorMessage = MessageUtil.getMessage("quest.error.complete.detail")
@@ -2357,8 +2357,8 @@ class QuestApiControllerTest @Autowired constructor(
             //given
             val savedQuest = questRepository.save(Quest("title", "desc", testUser, 1L, QuestState.PROCEED, QuestType.SUB))
 
-            val detailRequest = DetailRequest("detail", DetailQuestType.CHECK, 1)
-            savedQuest.updateDetailQuests(listOf(detailRequest))
+            val detailRequest = DetailQuest("detail", 1, DetailQuestType.CHECK, DetailQuestState.PROCEED , savedQuest)
+            savedQuest.updateDetailQuests(listOf(Pair(null, detailRequest)))
 
             val detailQuestId = savedQuest.detailQuests[0].id
 
@@ -2405,8 +2405,8 @@ class QuestApiControllerTest @Autowired constructor(
         fun `다른 유저의 퀘스트를 요청하면 FORBIDDEN이 반환된다`() {
             val savedQuest = questRepository.save(Quest("title", "desc", anotherUser, 1L, QuestState.PROCEED, QuestType.SUB))
 
-            val detailRequest = DetailRequest("detail", DetailQuestType.CHECK, 1)
-            savedQuest.updateDetailQuests(listOf(detailRequest))
+            val detailRequest = DetailQuest("detail", 1, DetailQuestType.CHECK, DetailQuestState.PROCEED , savedQuest)
+            savedQuest.updateDetailQuests(listOf(Pair(null, detailRequest)))
 
             questRepository.flush()
 
@@ -2512,8 +2512,8 @@ class QuestApiControllerTest @Autowired constructor(
         fun `진행중인 퀘스트가 아니라면 BAD_REQUEST가 반환된다`() {
             val savedQuest = questRepository.save(Quest("title", "desc", testUser, 1L, QuestState.FAIL, QuestType.SUB))
 
-            val detailRequest = DetailRequest("detail", DetailQuestType.CHECK, 1)
-            savedQuest.updateDetailQuests(listOf(detailRequest))
+            val detailRequest = DetailQuest("detail", 1, DetailQuestType.CHECK, DetailQuestState.PROCEED , savedQuest)
+            savedQuest.updateDetailQuests(listOf(Pair(null, detailRequest)))
 
             questRepository.flush()
 
@@ -2559,8 +2559,8 @@ class QuestApiControllerTest @Autowired constructor(
                 val savedQuest = questRepository.save(Quest("title", "desc", testUser, 1L, QuestState.PROCEED, QuestType.SUB))
 
                 val targetCount = 3
-                val detailRequest = DetailRequest("detail", DetailQuestType.COUNT, targetCount)
-                savedQuest.updateDetailQuests(listOf(detailRequest))
+                val detailRequest = DetailQuest("detail", targetCount, DetailQuestType.COUNT, DetailQuestState.PROCEED , savedQuest)
+                savedQuest.updateDetailQuests(listOf(Pair(null, detailRequest)))
 
                 questRepository.flush()
 
@@ -2608,8 +2608,8 @@ class QuestApiControllerTest @Autowired constructor(
                 val savedQuest = questRepository.save(Quest("title", "desc", testUser, 1L, QuestState.PROCEED, QuestType.SUB))
 
                 val targetCount = 5
-                val detailRequest = DetailRequest("detail", DetailQuestType.COUNT, targetCount)
-                savedQuest.updateDetailQuests(listOf(detailRequest))
+                val detailRequest = DetailQuest("detail", targetCount, DetailQuestType.COUNT, DetailQuestState.PROCEED , savedQuest)
+                savedQuest.updateDetailQuests(listOf(Pair(null, detailRequest)))
 
                 questRepository.flush()
 
@@ -2670,8 +2670,8 @@ class QuestApiControllerTest @Autowired constructor(
                 val savedQuest = questRepository.save(Quest("title", "desc", testUser, 1L, QuestState.PROCEED, QuestType.SUB))
 
                 val targetCount = 5
-                val detailRequest = DetailRequest("detail", DetailQuestType.COUNT, targetCount)
-                savedQuest.updateDetailQuests(listOf(detailRequest))
+                val detailRequest = DetailQuest("detail", targetCount, DetailQuestType.COUNT, DetailQuestState.PROCEED , savedQuest)
+                savedQuest.updateDetailQuests(listOf(Pair(null, detailRequest)))
 
                 questRepository.flush()
 
@@ -2723,8 +2723,8 @@ class QuestApiControllerTest @Autowired constructor(
                 val savedQuest = questRepository.save(Quest("title", "desc", testUser, 1L, QuestState.PROCEED, QuestType.SUB))
 
                 val targetCount = 5
-                val detailRequest = DetailRequest("detail", DetailQuestType.COUNT, targetCount)
-                savedQuest.updateDetailQuests(listOf(detailRequest))
+                val detailRequest = DetailQuest("detail", targetCount, DetailQuestType.COUNT, DetailQuestState.PROCEED , savedQuest)
+                savedQuest.updateDetailQuests(listOf(Pair(null, detailRequest)))
 
                 questRepository.flush()
 


### PR DESCRIPTION
- 퀘스트 엔티티 내부에서 DTO와 정적 유틸에 대한 외부 참조 제거
- 퀘스트 엔티티 메서드에 포함된 비즈니스 로직 서비스 레이어로 이동
- 퀘스트 엔티티 메서드의 반환값 추가
- 퀘스트 엔티티 반환값에 대한 Javadoc 추가
- 세부 퀘스트 엔티티에서 DTO 참조 제거
- 엔티티 변경에 따라 테스트 코드 수정