### PR TITLE
fix: 현재 퀘스트 조회 시 퀘스트 범위 조건 추가

### DIFF
--- a/dailyquest_web/src/main/java/dailyquest/quest/repository/QuestRepository.java
+++ b/dailyquest_web/src/main/java/dailyquest/quest/repository/QuestRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import dailyquest.quest.entity.Quest;
 import dailyquest.quest.entity.QuestState;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -17,6 +18,6 @@ public interface QuestRepository extends JpaRepository<Quest, Long>, QuestReposi
     @Query("select q from Quest q where q.user.id = :userId and q.id in :searchedIds")
     Page<Quest> getSearchedQuests(@Param("userId") Long userId, @Param("searchedIds") List<Long> searchedIds, Pageable pageable);
 
-    @Query("select q from Quest q where q.user.id = :userId and q.state= :state")
-    List<Quest> getCurrentQuests(@Param("userId") Long userId, @Param("state") QuestState state);
+    @Query("select q from Quest q where q.user.id = :userId and q.state= :state and q.createdDate between :prevReset and :nextReset")
+    List<Quest> getCurrentQuests(@Param("userId") Long userId, @Param("state") QuestState state, @Param("prevReset") LocalDateTime prevReset, @Param("nextReset") LocalDateTime nextReset);
 }


### PR DESCRIPTION
- 진행 상태가 아닌 현재 퀘스트 조회 시 이전에 처리된 퀘스트도 조회되는 문제 수정
- 퀘스트 조회 시에 유저의 초기화 구간을 계산해 현재 구간에 포함된 퀘스트만 조회하도록 변경