### PR TITLE
퀘스트 등록 시 saveAndFlush 호출로 변경

### DIFF
--- a/web/src/main/java/dailyquest/quest/service/QuestCommandService.java
+++ b/web/src/main/java/dailyquest/quest/service/QuestCommandService.java
@@ -37,7 +37,7 @@ public class QuestCommandService {
     public QuestResponse saveQuest(WebQuestRequest dto, Long userId) {
         Long nextSeq = questRepository.getNextSeqOfUser(userId);
         Quest quest = dto.mapToEntity(nextSeq, userId);
-        questRepository.save(quest);
+        questRepository.saveAndFlush(quest);
         QuestLogRequest questLogRequest = QuestLogRequest.from(quest);
         questLogService.saveQuestLog(questLogRequest);
         userRecordService.recordQuestRegistration(userId, questLogRequest.getLoggedDate());


### PR DESCRIPTION
Auditing 값을 이후 로직에서 사용하기 위해 사전에 flush 호출이 필수적임
이전에 퀘스트 커맨드 로직을 수정할 때 누락된 것으로 보임