### PR TITLE
메시지 소스 액세서 빈 추가

### DIFF
--- a/achievement/src/main/kotlin/dailyquest/achievement/service/AchievementService.kt
+++ b/achievement/src/main/kotlin/dailyquest/achievement/service/AchievementService.kt
@@ -8,7 +8,6 @@ import dailyquest.achievement.entity.Achievement
 import dailyquest.achievement.entity.AchievementType
 import dailyquest.achievement.repository.AchievementRepository
 import dailyquest.properties.AchievementPageSizeProperties
-import org.springframework.context.MessageSource
 import org.springframework.context.support.MessageSourceAccessor
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -23,10 +22,8 @@ class AchievementService(
     private val achievementPageSizeProperties: AchievementPageSizeProperties,
     private val achieveLogCommandService: AchievementAchieveLogCommandService,
     private val achieveLogQueryService: AchievementAchieveLogQueryService,
-    messageSource: MessageSource
+    private val messageSourceAccessor: MessageSourceAccessor
 ) {
-    private val messageSourceAccessor: MessageSourceAccessor = MessageSourceAccessor(messageSource)
-
     fun getAchievedAchievements(userId: Long, page: Int): Page<AchievementResponse> {
         val pageRequest = PageRequest.of(page, achievementPageSizeProperties.size)
         return achieveLogQueryService.getAchievedAchievements(userId, pageRequest)

--- a/achievement/src/test/unit/dailyquest/achievement/service/AchievementServiceUnitTest.kt
+++ b/achievement/src/test/unit/dailyquest/achievement/service/AchievementServiceUnitTest.kt
@@ -20,7 +20,7 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.context.MessageSource
+import org.springframework.context.support.MessageSourceAccessor
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 
@@ -38,7 +38,7 @@ class AchievementServiceUnitTest {
     @RelaxedMockK
     private lateinit var notificationService: NotificationService
     @RelaxedMockK
-    private lateinit var messageSource: MessageSource
+    private lateinit var messageSourceAccessor: MessageSourceAccessor
     @InjectMockKs
     private lateinit var achievementService: AchievementService
 

--- a/batch/src/main/kotlin/dailyquest/config/MessageSourceConfig.kt
+++ b/batch/src/main/kotlin/dailyquest/config/MessageSourceConfig.kt
@@ -1,0 +1,14 @@
+package dailyquest.config
+
+import org.springframework.context.MessageSource
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.support.MessageSourceAccessor
+
+@Configuration
+class MessageSourceConfig {
+    @Bean
+    fun messageSourceAccessor(messageSource: MessageSource): MessageSourceAccessor {
+        return MessageSourceAccessor(messageSource)
+    }
+}

--- a/user/src/main/kotlin/dailyquest/user/service/UserService.kt
+++ b/user/src/main/kotlin/dailyquest/user/service/UserService.kt
@@ -9,7 +9,6 @@ import dailyquest.user.entity.User
 import dailyquest.user.record.service.UserRecordService
 import dailyquest.user.repository.UserRepository
 import jakarta.persistence.EntityNotFoundException
-import org.springframework.context.MessageSource
 import org.springframework.context.support.MessageSourceAccessor
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,10 +20,8 @@ import kotlin.jvm.optionals.getOrNull
 class UserService(
     private val userRepository: UserRepository,
     private val userRecordService: UserRecordService,
-    messageSource: MessageSource
+    private val messageSourceAccessor: MessageSourceAccessor
 ) {
-    private val messageSourceAccessor: MessageSourceAccessor = MessageSourceAccessor(messageSource)
-
     fun findUserByOauthId(oauth2Id: String): UserResponse? {
         return userRepository.findByOauth2Id(oauth2Id)?.let { UserResponse.from(it) }
     }

--- a/user/src/test/unit/dailyquest/user/service/UserServiceUnitTest.kt
+++ b/user/src/test/unit/dailyquest/user/service/UserServiceUnitTest.kt
@@ -16,7 +16,7 @@ import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.context.MessageSource
+import org.springframework.context.support.MessageSourceAccessor
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDateTime
 
@@ -31,7 +31,7 @@ class UserServiceUnitTest {
     @RelaxedMockK
     private lateinit var userRecordService: UserRecordService
     @RelaxedMockK
-    private lateinit var messageSource: MessageSource
+    private lateinit var messageSourceAccessor: MessageSourceAccessor
     @RelaxedMockK
     private lateinit var user: User
 

--- a/web/src/main/java/dailyquest/config/MessageSourceConfig.java
+++ b/web/src/main/java/dailyquest/config/MessageSourceConfig.java
@@ -1,0 +1,14 @@
+package dailyquest.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.MessageSourceAccessor;
+
+@Configuration
+public class MessageSourceConfig {
+    @Bean
+    public MessageSourceAccessor messageSourceAccessor(MessageSource messageSource) {
+        return new MessageSourceAccessor(messageSource);
+    }
+}

--- a/web/src/main/java/dailyquest/exception/RestApiExceptionHandler.kt
+++ b/web/src/main/java/dailyquest/exception/RestApiExceptionHandler.kt
@@ -1,8 +1,15 @@
 package dailyquest.exception
 
+import dailyquest.common.MessageUtil
+import dailyquest.common.ResponseData
 import jakarta.persistence.EntityNotFoundException
+import jakarta.persistence.OptimisticLockException
+import jakarta.persistence.PersistenceException
 import jakarta.validation.ConstraintViolationException
+import org.hibernate.StaleObjectStateException
+import org.hibernate.dialect.lock.OptimisticEntityLockException
 import org.slf4j.LoggerFactory
+import org.springframework.context.support.MessageSourceAccessor
 import org.springframework.http.HttpStatus
 import org.springframework.http.converter.HttpMessageConversionException
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -17,22 +24,12 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.NoHandlerFoundException
-import dailyquest.common.MessageUtil
-import dailyquest.common.ResponseData
-import jakarta.persistence.OptimisticLockException
-import jakarta.persistence.PersistenceException
-import org.hibernate.StaleObjectStateException
-import org.hibernate.dialect.lock.OptimisticEntityLockException
-import org.springframework.context.MessageSource
-import org.springframework.context.support.MessageSourceAccessor
 import java.util.function.Consumer
 
 @RestControllerAdvice
 class RestApiExceptionHandler(
-    messageSource: MessageSource
+    private val messageSourceAccessor: MessageSourceAccessor
 ) {
-    private val messageSourceAccessor = MessageSourceAccessor(messageSource)
-
     var log = LoggerFactory.getLogger(this.javaClass)
 
     @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/web/src/main/java/dailyquest/quest/service/QuestCommandService.java
+++ b/web/src/main/java/dailyquest/quest/service/QuestCommandService.java
@@ -8,12 +8,12 @@ import dailyquest.redis.service.RedisService;
 import dailyquest.user.record.service.UserRecordService;
 import dailyquest.user.service.UserService;
 import jakarta.persistence.EntityNotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.MessageSource;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@RequiredArgsConstructor
 @Transactional
 @Service
 public class QuestCommandService {
@@ -23,16 +23,6 @@ public class QuestCommandService {
     private final QuestLogService questLogService;
     private final RedisService redisService;
     private final MessageSourceAccessor messageSourceAccessor;
-
-    @Autowired
-    public QuestCommandService(QuestRepository questRepository, UserService userService, UserRecordService userRecordService, QuestLogService questLogService, RedisService redisService, MessageSource messageSource) {
-        this.questRepository = questRepository;
-        this.userService = userService;
-        this.userRecordService = userRecordService;
-        this.questLogService = questLogService;
-        this.redisService = redisService;
-        this.messageSourceAccessor = new MessageSourceAccessor(messageSource);
-    }
 
     public QuestResponse saveQuest(WebQuestRequest dto, Long userId) {
         Long nextSeq = questRepository.getNextSeqOfUser(userId);

--- a/web/src/main/java/dailyquest/quest/service/QuestQueryService.java
+++ b/web/src/main/java/dailyquest/quest/service/QuestQueryService.java
@@ -6,8 +6,7 @@ import dailyquest.quest.entity.Quest;
 import dailyquest.quest.entity.QuestState;
 import dailyquest.quest.repository.QuestRepository;
 import jakarta.persistence.EntityNotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.MessageSource;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,18 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class QuestQueryService {
 
     private final QuestRepository questRepository;
     private final MessageSourceAccessor messageSourceAccessor;
-
-    @Autowired
-    public QuestQueryService(QuestRepository questRepository, MessageSource messageSource) {
-        this.questRepository = questRepository;
-        this.messageSourceAccessor = new MessageSourceAccessor(messageSource);
-    }
 
     public List<QuestResponse> getCurrentQuests(Long userId, QuestState state) {
         LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);

--- a/web/src/main/java/dailyquest/user/controller/UserApiController.kt
+++ b/web/src/main/java/dailyquest/user/controller/UserApiController.kt
@@ -7,7 +7,6 @@ import dailyquest.user.dto.UserPrincipal
 import dailyquest.user.dto.WebUserUpdateRequest
 import dailyquest.user.service.UserService
 import jakarta.validation.Valid
-import org.springframework.context.MessageSource
 import org.springframework.context.support.MessageSourceAccessor
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.ResponseEntity
@@ -21,10 +20,8 @@ import org.springframework.web.bind.annotation.*
 class UserApiController(
     private val userService: UserService,
     private val notificationService: NotificationService,
-    messageSource: MessageSource
+    private val messageSourceAccessor: MessageSourceAccessor
 ) {
-    private val messageSourceAccessor = MessageSourceAccessor(messageSource)
-
     @GetMapping
     fun getPrincipal(@AuthenticationPrincipal principal: UserPrincipal): ResponseEntity<ResponseData<UserPrincipal>> {
         principal.notificationCount = notificationService.getNotConfirmedNotificationCount(principal.id)

--- a/web/src/test/unit/dailyquest/annotation/WebMvcUnitTest.kt
+++ b/web/src/test/unit/dailyquest/annotation/WebMvcUnitTest.kt
@@ -1,14 +1,17 @@
 package dailyquest.annotation
 
+import dailyquest.config.MessageSourceConfig
 import dailyquest.config.SecurityConfig
 import dailyquest.filter.InternalApiKeyValidationFilter
 import dailyquest.jwt.JwtAuthorizationFilter
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
 import org.springframework.core.annotation.AliasFor
 import kotlin.reflect.KClass
 
+@Import(MessageSourceConfig::class)
 @WithCustomMockUser
 @WebMvcTest(
     excludeFilters = [

--- a/web/src/test/unit/dailyquest/jwt/controller/JwtControllerUnitTest.java
+++ b/web/src/test/unit/dailyquest/jwt/controller/JwtControllerUnitTest.java
@@ -3,6 +3,7 @@ package dailyquest.jwt.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dailyquest.annotation.WithCustomMockUser;
+import dailyquest.config.MessageSourceConfig;
 import dailyquest.config.SecurityConfig;
 import dailyquest.filter.InternalApiKeyValidationFilter;
 import dailyquest.jwt.JwtAuthorizationFilter;
@@ -19,6 +20,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,6 +32,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 @SuppressWarnings("ALL")
+@Import(MessageSourceConfig.class)
 @ExtendWith(MockitoExtension.class)
 @WebMvcTest(controllers = JwtController.class,
         excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthorizationFilter.class, InternalApiKeyValidationFilter.class})})

--- a/web/src/test/unit/dailyquest/quest/service/QuestCommandServiceUnitTest.java
+++ b/web/src/test/unit/dailyquest/quest/service/QuestCommandServiceUnitTest.java
@@ -18,7 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.MessageSource;
+import org.springframework.context.support.MessageSourceAccessor;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -37,7 +37,7 @@ public class QuestCommandServiceUnitTest {
     @Mock UserService userService;
     @Mock UserRecordService userRecordService;
     @Mock QuestLogService questLogService;
-    @Mock MessageSource messageSource;
+    @Mock MessageSourceAccessor messageSourceAccessor;
     @Mock RedisService redisService;
     MockedStatic<QuestLogRequest> mockedStatic;
     MockedStatic<QuestResponse> mockedQuestResponse;

--- a/web/src/test/unit/dailyquest/quest/service/QuestQueryServiceUnitTest.java
+++ b/web/src/test/unit/dailyquest/quest/service/QuestQueryServiceUnitTest.java
@@ -13,7 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.MessageSource;
+import org.springframework.context.support.MessageSourceAccessor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -29,11 +29,12 @@ public class QuestQueryServiceUnitTest {
 
     @InjectMocks QuestQueryService questQueryService;
     @Mock QuestRepository questRepository;
-    @Mock MessageSource messageSource;
+    @Mock MessageSourceAccessor messageSourceAccessor;
 
     @BeforeEach
     void beforeEach() {
-        lenient().doReturn("").when(messageSource).getMessage(any(), any(), any());
+        lenient().doReturn("").when(messageSourceAccessor).getMessage(anyString());
+        lenient().doReturn("").when(messageSourceAccessor).getMessage(anyString(), any(Object[].class));
     }
 
     @DisplayName("현재 퀘스트 조회 시")

--- a/web/src/test/unit/dailyquest/status/controller/StatusApiControllerUnitTest.java
+++ b/web/src/test/unit/dailyquest/status/controller/StatusApiControllerUnitTest.java
@@ -1,6 +1,7 @@
 package dailyquest.status.controller;
 
 import dailyquest.annotation.WithCustomMockUser;
+import dailyquest.config.MessageSourceConfig;
 import dailyquest.config.SecurityConfig;
 import dailyquest.filter.InternalApiKeyValidationFilter;
 import dailyquest.jwt.JwtAuthorizationFilter;
@@ -17,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -28,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Import(MessageSourceConfig.class)
 @ExtendWith(MockitoExtension.class)
 @WebMvcTest(controllers = StatusApiController.class,
         excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthorizationFilter.class, InternalApiKeyValidationFilter.class})})

--- a/web/src/test/unit/dailyquest/user/controller/UserControllerUnitTest.kt
+++ b/web/src/test/unit/dailyquest/user/controller/UserControllerUnitTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.ninjasquad.springmockk.MockkBean
 import dailyquest.annotation.WithCustomMockUser
+import dailyquest.config.MessageSourceConfig
 import dailyquest.config.SecurityConfig
 import dailyquest.filter.InternalApiKeyValidationFilter
 import dailyquest.jwt.JwtAuthorizationFilter
@@ -26,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
 import org.springframework.context.support.MessageSourceAccessor
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.MediaType
@@ -40,6 +42,7 @@ import java.util.stream.Stream
 @Suppress("DEPRECATION")
 @DisplayName("유저 API 컨트롤러 유닛 테스트")
 @WithCustomMockUser
+@Import(MessageSourceConfig::class)
 @WebMvcTest(controllers = [UserApiController::class],
     excludeFilters = [
         ComponentScan.Filter(

--- a/web/src/test/unit/dailyquest/user/controller/UserControllerUnitTest.kt
+++ b/web/src/test/unit/dailyquest/user/controller/UserControllerUnitTest.kt
@@ -24,9 +24,9 @@ import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.MessageSource
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.context.support.MessageSourceAccessor
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
@@ -64,7 +64,7 @@ class UserControllerUnitTest {
     lateinit var notificationService: NotificationService
 
     @MockkBean(relaxed = true)
-    lateinit var messageSource: MessageSource
+    lateinit var messageSourceAccessor: MessageSourceAccessor
 
     val om: ObjectMapper = ObjectMapper().registerModule(JavaTimeModule())
 


### PR DESCRIPTION
메시지 소스 액세서 객체를 각 컴포넌트에서 생성하는 대신 빈으로 등록해서 사용하도록 개선